### PR TITLE
Update CI workflow permissions and NPM token usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
+      issues: write
+      pull-requests: write
 
     steps:
       # Checkout the repository code
@@ -84,5 +85,5 @@ jobs:
       - name: Release to NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- Fixes NPM auth for semantic-release by using secrets.NPM_TOKEN directly (no fallback/invalid expression).
-  Adds required GitHub permissions for semantic-release GitHub plugin (issues / pull-requests).

## Why
- CI release was failing with E401 Unauthorized / EINVALIDNPMTOKEN.
- semantic-release GitHub failure reporting was failing with Resource not accessible by integration (403).

## Test Plan
- Open PR and verify CI/CD Pipeline / Build and Test passes.
- Ensure Release to NPM does not run on PR (push-only on main/master).
- After merge to main, verify release job can authenticate to npm and complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the release workflow to fix npm authentication and enable semantic-release GitHub interactions.
> 
> - In `.github/workflows/ci.yml` release job: add `permissions` for `issues: write` and `pull-requests: write`; remove `packages: write`
> - Set `NODE_AUTH_TOKEN` to `secrets.NPM_TOKEN` (remove fallback expression) for semantic-release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f6d6eeca93540eadac201e39dbb03b61b00fba1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->