### PR TITLE
feat: extend Fetch Page Content to News Search + docs audit (v32.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [32.8.0] - 2026-06-24
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Page content extraction now also works for News Search.** The opt-in **Fetch Page Content** option (and its `pageContentMaxResults` / `pageContentMaxLength` / `pageContentTimeout` controls) is now available on News Search, fetching each article's page and extracting its main text into `pageContent`. The same three-tier extractor (Readability → DOM heuristic → regex) and per-result error handling apply. Web and News now share a single enrichment path.
+
+---
+
 ## [32.7.0] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Searches DuckDuckGo and returns organic web results.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query` | string | required | Search terms |
-| `maxResults` | number | 10 | Number of results (1–50) |
+| `maxResults` | number | 10 | Number of results (1–100) |
 | `safeSearch` | options | Moderate | `Strict`, `Moderate`, or `Off` |
 | `region` | string | wt-wt | Locale code (e.g. `de-de`, `fr-fr`) |
 | `useSearchOperators` | boolean | false | Enable advanced operator parsing |
@@ -124,7 +124,7 @@ Searches DuckDuckGo images and returns image metadata.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `imageQuery` | string | required | Image search terms |
-| `maxResults` | number | 10 | Number of results (1–50) |
+| `maxResults` | number | 10 | Number of results (1–100) |
 | `safeSearch` | options | Moderate | `Strict`, `Moderate`, or `Off` |
 
 **Example:**
@@ -170,7 +170,7 @@ Searches DuckDuckGo news results.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `newsQuery` | string | required | News search terms |
-| `maxResults` | number | 10 | Number of results (1–50) |
+| `maxResults` | number | 10 | Number of results (1–100) |
 | `safeSearch` | options | Moderate | `Strict`, `Moderate`, or `Off` |
 | `region` | string | wt-wt | Locale code |
 | `timePeriod` | string | — | Time filter: `d` (day), `w` (week), `m` (month), `y` (year) |
@@ -222,7 +222,7 @@ Searches DuckDuckGo video results.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `videoQuery` | string | required | Video search terms |
-| `maxResults` | number | 10 | Number of results (1–50) |
+| `maxResults` | number | 10 | Number of results (1–100) |
 | `safeSearch` | options | Moderate | `Strict`, `Moderate`, or `Off` |
 | `region` | string | wt-wt | Locale code |
 
@@ -269,7 +269,7 @@ Searches DuckDuckGo video results.
 
 | Parameter | Type | Default | Values |
 |-----------|------|---------|--------|
-| `maxResults` | number | 10 | 1–50 |
+| `maxResults` | number | 10 | 1–100 |
 | `safeSearch` | options | Moderate | `Strict`, `Moderate`, `Off` |
 | `region` | string | `wt-wt` | DuckDuckGo locale code (e.g. `de-de`, `fr-fr`) |
 
@@ -277,7 +277,7 @@ Searches DuckDuckGo video results.
 
 | Operation | Extra parameters |
 |-----------|-----------------|
-| Web Search | `useSearchOperators`, `searchOperators` |
+| Web Search | `useSearchOperators`, `searchOperators`, `fetchPageContent` (+ `pageContentMaxResults`, `pageContentMaxLength`, `pageContentTimeout`) |
 | News Search | `timePeriod` (`d`, `w`, `m`, `y`) |
 | Image Search | *(none beyond common)* |
 | Video Search | *(none beyond common)* |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An n8n community node for DuckDuckGo search. Search the web, find images, discov
 - **Search operators**: Advanced query syntax for Web Search (`site:`, `filetype:`, `intitle:`, etc.)
 - **Region/locale support**: Configure DuckDuckGo locale codes per operation
 - **Safe search**: Configurable per operation
-- **Optional page content extraction**: Fetch and extract the main text of result pages (Web Search, opt-in)
+- **Optional page content extraction**: Fetch and extract the main text of result pages (Web and News, opt-in)
 
 ---
 
@@ -174,6 +174,10 @@ Searches DuckDuckGo news results.
 | `safeSearch` | options | Moderate | `Strict`, `Moderate`, or `Off` |
 | `region` | string | wt-wt | Locale code |
 | `timePeriod` | string | — | Time filter: `d` (day), `w` (week), `m` (month), `y` (year) |
+| `fetchPageContent` | boolean | false | Fetch each article's page and extract its main text (opt-in; see [Page Content Extraction](#-page-content-extraction)) |
+| `pageContentMaxResults` | number | 3 | How many top results to fetch content for (when enabled) |
+| `pageContentMaxLength` | number | 2000 | Truncate extracted text to N characters (0 = no limit) |
+| `pageContentTimeout` | number | 8000 | Per-page fetch timeout in ms |
 
 **Example:**
 
@@ -278,7 +282,7 @@ Searches DuckDuckGo video results.
 | Operation | Extra parameters |
 |-----------|-----------------|
 | Web Search | `useSearchOperators`, `searchOperators`, `fetchPageContent` (+ `pageContentMaxResults`, `pageContentMaxLength`, `pageContentTimeout`) |
-| News Search | `timePeriod` (`d`, `w`, `m`, `y`) |
+| News Search | `timePeriod` (`d`, `w`, `m`, `y`), `fetchPageContent` (+ `pageContentMaxResults`, `pageContentMaxLength`, `pageContentTimeout`) |
 | Image Search | *(none beyond common)* |
 | Video Search | *(none beyond common)* |
 
@@ -339,6 +343,9 @@ Cache is in-memory only and is not shared across n8n worker processes or restart
 | `isOld` | boolean | Whether DuckDuckGo considers the article old |
 | `isFallback` | boolean | `true` if result came from fallback path |
 | `sourceType` | string | Always `"news"` |
+| `pageContent` | string | Extracted main text of the article page (only when **Fetch Page Content** is enabled; empty for results beyond the fetched top-N) |
+| `pageContentTruncated` | boolean | Present and `true` when `pageContent` was cut to `pageContentMaxLength` |
+| `pageContentError` | string | Present only when the page could not be fetched/parsed |
 
 ### Video Search
 
@@ -572,7 +579,7 @@ The primary search path failed and the fallback HTML path was used. Results are 
 
 By default, Web Search returns DuckDuckGo's short snippet (the `description` field). DuckDuckGo controls that snippet length, and the node already returns all of it.
 
-To get **more text**, enable **Fetch Page Content** (Web Search only, off by default). The node then fetches the actual page behind each of the top results and extracts its main readable text into a `pageContent` field.
+To get **more text**, enable **Fetch Page Content** (available on **Web Search** and **News Search**, off by default). The node then fetches the actual page behind each of the top results and extracts its main readable text into a `pageContent` field.
 
 | Option | Default | Purpose |
 |--------|---------|---------|
@@ -614,7 +621,7 @@ To get **more text**, enable **Fetch Page Content** (Web Search only, off by def
 - **No analytics or telemetry**: This node contains no telemetry or analytics code. No query data, result data, or execution metadata is sent to any analytics or telemetry service. Search requests go to DuckDuckGo only.
 - **No credentials registered**: The n8n credential registry for this package is empty. n8n will not prompt for any DuckDuckGo credentials.
 - **Direct requests only (by default)**: Search requests go directly to DuckDuckGo (`duckduckgo.com`, `html.duckduckgo.com`, `i.js`). No third-party search API, proxy, or intermediary is involved. The one exception is the opt-in Fetch Page Content feature below.
-- **Optional page-content fetch (off by default)**: If you enable **Fetch Page Content** (Web Search), the node additionally requests each fetched result's page from its own third-party server to extract text. This is the only path that contacts non-DuckDuckGo hosts, and it is disabled unless you turn it on. See [Page Content Extraction](#-page-content-extraction).
+- **Optional page-content fetch (off by default)**: If you enable **Fetch Page Content** (Web or News Search), the node additionally requests each fetched result's page from its own third-party server to extract text. This is the only path that contacts non-DuckDuckGo hosts, and it is disabled unless you turn it on. See [Page Content Extraction](#-page-content-extraction).
 - **No disk storage**: The node does not write queries or results to disk. Optional in-memory caching may temporarily keep results for the configured cache TTL (default 5 minutes) within the running n8n process.
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,42 @@
+# v32.8.0 — Page Content Extraction for News Search
+
+**Release Date:** 2026-06-24
+
+Extends the opt-in Fetch Page Content feature (added in 32.7.0 for Web Search) to **News Search**.
+
+---
+
+## Highlights
+
+- **News Search now supports Fetch Page Content** (off by default). When enabled, the node fetches each article's page and extracts its main text into `pageContent`, with the same `pageContentMaxResults` / `pageContentMaxLength` / `pageContentTimeout` controls.
+- Uses the same three-tier extractor (Mozilla Readability → linkedom DOM heuristic → regex) and per-result error handling as Web Search. Web and News now share a single enrichment path.
+
+---
+
+## Privacy
+
+- Off by default. When enabled, the node fetches the third-party article pages — the only path that contacts non-DuckDuckGo hosts. Unchanged when off.
+
+## Compatibility
+
+- No breaking changes. The new fields (`pageContent`, `pageContentTruncated`, `pageContentError`) appear on News results only when the option is enabled.
+
+---
+
+## Validation
+
+- `tsc`, ESLint, full suite (242 tests across 11 suites), `npm run build:prod`, and `verify-build` all pass. Verified live in n8n 2.27.3 against real news queries.
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.8.0
+```
+
+---
+
 # v32.7.0 — Optional Page Content Extraction (Web Search)
 
 **Release Date:** 2026-06-23

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -120,6 +120,63 @@ function enhanceSearchQuery(query: string, searchType: string = 'web'): string {
   return enhancedQuery;
 }
 
+/**
+ * Opt-in enrichment: fetch the top-N result pages and attach their extracted
+ * main text as `pageContent` (with `pageContentTruncated` / `pageContentError`
+ * when relevant). No-op unless `fetchPageContent` is enabled. Shared by Web and
+ * News search. Makes HTTP requests to the third-party result sites.
+ */
+async function enrichWithPageContent(
+  results: INodeExecutionData[],
+  pageOpts: {
+    fetchPageContent?: boolean;
+    pageContentMaxResults?: number;
+    pageContentMaxLength?: number;
+    pageContentTimeout?: number;
+  },
+  debugMode: boolean,
+  operation: string,
+): Promise<void> {
+  if (!pageOpts.fetchPageContent || results.length === 0) {
+    return;
+  }
+  const count = Math.min(pageOpts.pageContentMaxResults ?? 3, results.length);
+  const pcOptions = {
+    timeout: pageOpts.pageContentTimeout ?? 8000,
+    maxLength: pageOpts.pageContentMaxLength ?? 2000,
+  };
+
+  // Initialise the field on every returned result for predictable output.
+  for (const r of results) {
+    r.json.pageContent = '';
+  }
+
+  const targets = results.slice(0, count);
+  const pcResults = await fetchPageContents(
+    targets.map(r => (typeof r.json.url === 'string' ? r.json.url : '')),
+    pcOptions,
+  );
+  targets.forEach((r, i) => {
+    const pc = pcResults[i];
+    r.json.pageContent = pc.content;
+    if (pc.truncated) {
+      r.json.pageContentTruncated = true;
+    }
+    if (pc.error) {
+      r.json.pageContentError = pc.error;
+    }
+  });
+
+  if (debugMode) {
+    console.log(JSON.stringify(createLogEntry(
+      LogLevel.INFO,
+      `Fetched page content for ${count} of ${results.length} ${operation} results`,
+      operation,
+      { count, pageContentOptions: pcOptions },
+    )));
+  }
+}
+
 
 /**
  * DuckDuckGo node implementation with cleanly separated operations
@@ -701,6 +758,60 @@ export class DuckDuckGo implements INodeType {
             default: false,
             description: 'Whether to return the raw API response instead of processed results',
           },
+          {
+            displayName: 'Fetch Page Content',
+            name: 'fetchPageContent',
+            type: 'boolean',
+            default: false,
+            description: 'Whether to fetch each article page and extract its main text into a pageContent field (makes extra requests to third-party sites, so it is slower and not limited to DuckDuckGo)',
+          },
+          {
+            displayName: 'Number of Results to Fetch',
+            name: 'pageContentMaxResults',
+            type: 'number',
+            default: 3,
+            description: 'How many of the top results to fetch and extract page content for',
+            typeOptions: {
+              minValue: 1,
+              maxValue: 20,
+            },
+            displayOptions: {
+              show: {
+                fetchPageContent: [true],
+              },
+            },
+          },
+          {
+            displayName: 'Max Content Length',
+            name: 'pageContentMaxLength',
+            type: 'number',
+            default: 2000,
+            description: 'Maximum number of characters of extracted text to keep, or 0 for no limit',
+            typeOptions: {
+              minValue: 0,
+            },
+            displayOptions: {
+              show: {
+                fetchPageContent: [true],
+              },
+            },
+          },
+          {
+            displayName: 'Page Fetch Timeout',
+            name: 'pageContentTimeout',
+            type: 'number',
+            default: 8000,
+            description: 'Maximum time in milliseconds to wait for each page to load',
+            typeOptions: {
+              minValue: 1000,
+              maxValue: 60000,
+            },
+            displayOptions: {
+              show: {
+                fetchPageContent: [true],
+              },
+            },
+          },
         ],
       },
 
@@ -1197,45 +1308,9 @@ export class DuckDuckGo implements INodeType {
                 results = processWebSearchResults(result.results as any, itemIndex, result).slice(0, maxResults);
 
                 // Optional, opt-in: enrich the top-N results with extracted page text.
-                // This makes extra HTTP requests to the result sites (not DuckDuckGo),
+                // Makes extra HTTP requests to the result sites (not DuckDuckGo),
                 // so it only runs when the user enables "Fetch Page Content".
-                if (options.fetchPageContent && results.length > 0) {
-                  const count = Math.min(options.pageContentMaxResults ?? 3, results.length);
-                  const pcOptions = {
-                    timeout: options.pageContentTimeout ?? 8000,
-                    maxLength: options.pageContentMaxLength ?? 2000,
-                  };
-
-                  // Initialise the field on every returned result for predictable output.
-                  for (const r of results) {
-                    r.json.pageContent = '';
-                  }
-
-                  const targets = results.slice(0, count);
-                  const pcResults = await fetchPageContents(
-                    targets.map(r => (typeof r.json.url === 'string' ? r.json.url : '')),
-                    pcOptions,
-                  );
-                  targets.forEach((r, i) => {
-                    const pc = pcResults[i];
-                    r.json.pageContent = pc.content;
-                    if (pc.truncated) {
-                      r.json.pageContentTruncated = true;
-                    }
-                    if (pc.error) {
-                      r.json.pageContentError = pc.error;
-                    }
-                  });
-
-                  if (debugMode) {
-                    console.log(JSON.stringify(createLogEntry(
-                      LogLevel.INFO,
-                      `Fetched page content for ${count} of ${results.length} web results`,
-                      operation,
-                      { count, pageContentOptions: pcOptions },
-                    )));
-                  }
-                }
+                await enrichWithPageContent(results, options, debugMode, operation);
 
                 // Add cache information to the first result if in debug mode
                 if (debugMode && results.length > 0) {
@@ -1491,6 +1566,10 @@ export class DuckDuckGo implements INodeType {
             region?: string;
             returnRawResults?: boolean;
             timePeriod?: string;
+            fetchPageContent?: boolean;
+            pageContentMaxResults?: number;
+            pageContentMaxLength?: number;
+            pageContentTimeout?: number;
           };
 
           // Set up search options with correct API according to duck-duck-scrape documentation
@@ -1683,6 +1762,9 @@ export class DuckDuckGo implements INodeType {
                 const maxResults = newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS;
                 results = processNewsSearchResults(result.results as any, itemIndex).slice(0, maxResults);
 
+                // Optional, opt-in: enrich the top-N results with extracted page text.
+                await enrichWithPageContent(results, newsSearchOptions, debugMode, operation);
+
                 // Add cache information to the first result if in debug mode
                 if (debugMode && results.length > 0) {
                   results[0].json.fromCache = result !== undefined;
@@ -1750,6 +1832,8 @@ export class DuckDuckGo implements INodeType {
                   }));
 
                   results = processNewsSearchResults(newsResults, itemIndex).slice(0, newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS);
+                  // Optional, opt-in: enrich fallback results too.
+                  await enrichWithPageContent(results, newsSearchOptions, debugMode, operation);
                 }
                 // If relevantResults is empty, fall through to the error-item path below
                 // so the caller gets a meaningful signal instead of silence.

--- a/nodes/DuckDuckGo/pageContent.ts
+++ b/nodes/DuckDuckGo/pageContent.ts
@@ -1,6 +1,6 @@
 /**
- * Optional page-content fetching and main-text extraction for Web Search
- * results.
+ * Optional page-content fetching and main-text extraction for Web and News
+ * Search results.
  *
  * IMPORTANT: fetching page content makes HTTP requests to the third-party
  * result sites — not only to DuckDuckGo. This module is used only when the

--- a/nodes/DuckDuckGo/pageContent.ts
+++ b/nodes/DuckDuckGo/pageContent.ts
@@ -1,6 +1,6 @@
 /**
- * Optional page-content fetching and lightweight, dependency-free main-text
- * extraction for Web Search results.
+ * Optional page-content fetching and main-text extraction for Web Search
+ * results.
  *
  * IMPORTANT: fetching page content makes HTTP requests to the third-party
  * result sites — not only to DuckDuckGo. This module is used only when the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.7.0",
+  "version": "32.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.7.0",
+      "version": "32.8.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
   "version": "32.7.0",
-  "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
+  "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",
     "n8n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.7.0",
+  "version": "32.8.0",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- **Extends the opt-in Fetch Page Content feature to News Search** (32.7.0 added it for Web Search).
- Plus a docs audit aligning all text with the 32.6/32.7 changes.

## Page content for News
- Adds the `fetchPageContent` option (+ `pageContentMaxResults` / `pageContentMaxLength` / `pageContentTimeout`) to News Search.
- Enriches both the primary (duck-duck-scrape) and HTML-fallback news result paths.
- News results gain `pageContent` (+ `pageContentTruncated` / `pageContentError`) via the same three-tier extractor (Readability → linkedom DOM heuristic → regex).
- Web and News now share one `enrichWithPageContent()` helper (web behaviour unchanged).

## Docs audit
- Dropped stale "dependency-free" wording (readability/linkedom are now deps).
- Fixed `maxResults` range 1–50 → 1–100 (matches the node).
- Documented page-content options/output for both Web and News; updated the Page Content section, operation-specific table, privacy notes, and CHANGELOG.

## Validation
`tsc` clean · ESLint clean · **242 tests / 11 suites** · `build:prod` + `verify-build` pass. Verified live in n8n 2.27.3: a News query returned clean article text for 8/10 results (the 2 empties were JS-rendered SPA pages — gracefully empty, documented).

Released as **v32.8.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)