### PR TITLE
feat: page metadata, Extract Page Content + Instant Answer operations (v32.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [32.9.0] - 2026-06-24
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **New operation: Extract Page Content.** Give the node any URL and it fetches the page and returns the main text (`content`) plus optional metadata, using the same three-tier extractor (Readability → DOM heuristic → regex) as search. Turns the node into a "read any page" tool for AI agents.
+- **New operation: Instant Answer.** Queries DuckDuckGo's official, free, no-key Instant Answer API and returns a direct `answer`, `abstract` (Wikipedia-style summary), `definition`, `relatedTopics`, image, source, and type.
+- **Page metadata for Fetch Page Content.** A new **Include Page Metadata** sub-option adds `pageTitle`, `pageAuthor`, `pagePublished`, `pageExcerpt`, and `pageSiteName` (from Readability) to Web and News results when the page is an article.
+
+All three are free, require no API key, and add no paid or external dependencies (they reuse axios + the existing extractor / DuckDuckGo's own endpoints).
+
+---
+
 ## [32.8.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ An n8n community node for DuckDuckGo search. Search the web, find images, discov
 - **Search operators**: Advanced query syntax for Web Search (`site:`, `filetype:`, `intitle:`, etc.)
 - **Region/locale support**: Configure DuckDuckGo locale codes per operation
 - **Safe search**: Configurable per operation
-- **Optional page content extraction**: Fetch and extract the main text of result pages (Web and News, opt-in)
+- **Optional page content extraction**: Fetch and extract the main text of result pages (Web and News, opt-in), with optional page metadata
+- **Extract Page Content operation**: Give any URL → clean main text + metadata (a "read any page" tool for AI Agents)
+- **Instant Answer operation**: Direct answers, abstracts, and definitions from DuckDuckGo's free Instant Answer API
 
 ---
 
@@ -267,6 +269,66 @@ Searches DuckDuckGo video results.
 
 ---
 
+### Extract Page Content
+
+Fetches **any URL** (not a search) and extracts its main readable text — useful when an AI Agent already has a URL and needs to read the page.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | string | required | The page URL to fetch and extract |
+| `pageContentMaxLength` | number | 2000 | Truncate extracted text to N characters (0 = no limit) |
+| `pageContentTimeout` | number | 8000 | Fetch timeout in ms |
+| `includePageMetadata` | boolean | false | Also return title/author/published/excerpt/siteName when the page is an article |
+
+**Sample output:**
+
+```json
+{
+  "url": "https://example.com/article",
+  "content": "Extracted main text of the page…",
+  "sourceType": "pageContent",
+  "title": "Article Title",
+  "siteName": "Example"
+}
+```
+
+> ⚠️ This operation fetches a third-party URL directly (not DuckDuckGo). See [Privacy & Security](#-privacy--security).
+
+---
+
+### Instant Answer
+
+Returns DuckDuckGo's **Instant Answer** for a query — a direct answer, a Wikipedia-style abstract, a definition, and related topics — via the official **free, no-key** API.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `instantAnswerQuery` | string | required | The term or question (e.g. a person, place, or concept) |
+
+**Sample output:**
+
+```json
+{
+  "query": "DuckDuckGo",
+  "heading": "DuckDuckGo",
+  "abstract": "DuckDuckGo is an internet search engine that emphasizes protecting searchers' privacy…",
+  "abstractSource": "Wikipedia",
+  "abstractURL": "https://en.wikipedia.org/wiki/DuckDuckGo",
+  "relatedTopics": [
+    { "text": "…", "url": "https://duckduckgo.com/…" }
+  ],
+  "type": "A",
+  "sourceType": "instantAnswer"
+}
+```
+
+> **Note:** Instant Answers exist only for some queries (entities, definitions, calculations). For general queries the fields may be empty — use Web Search instead.
+
+---
+
 ## ⚙️ Configuration Reference
 
 ### Common Parameters (all operations)
@@ -285,6 +347,8 @@ Searches DuckDuckGo video results.
 | News Search | `timePeriod` (`d`, `w`, `m`, `y`), `fetchPageContent` (+ `pageContentMaxResults`, `pageContentMaxLength`, `pageContentTimeout`) |
 | Image Search | *(none beyond common)* |
 | Video Search | *(none beyond common)* |
+| Extract Page Content | `url`, `pageContentMaxLength`, `pageContentTimeout`, `includePageMetadata` |
+| Instant Answer | `instantAnswerQuery` |
 
 ### Cache Settings
 
@@ -587,6 +651,7 @@ To get **more text**, enable **Fetch Page Content** (available on **Web Search**
 | `pageContentMaxResults` | `3` | Fetch content for the top N results only (controls speed) |
 | `pageContentMaxLength` | `2000` | Truncate each `pageContent` to N characters (`0` = no limit) |
 | `pageContentTimeout` | `8000` | Per-page fetch timeout in milliseconds |
+| `includePageMetadata` | `false` | Also add `pageTitle` / `pageAuthor` / `pagePublished` / `pageExcerpt` / `pageSiteName` (when the page is an article) |
 
 **How it works:** extraction is three-tiered — (1) [Mozilla Readability](https://github.com/mozilla/readability) over a lightweight [linkedom](https://github.com/WebReflection/linkedom) DOM pulls the main article text and drops nav/boilerplate; (2) when Readability finds no article, a DOM heuristic removes boilerplate and high link-density blocks (menus not wrapped in `<nav>`); (3) if DOM parsing fails, a dependency-free regex heuristic is the last resort. The result feeds clean text to downstream nodes or AI agents.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,44 @@
+# v32.9.0 — Page Metadata, Extract-from-URL, and Instant Answers
+
+**Release Date:** 2026-06-24
+
+Three free, no-key, no-new-dependency additions that make the node a fuller research toolkit.
+
+---
+
+## Highlights
+
+- **New operation: Extract Page Content** — give the node any URL and it returns the page's main text (`content`) plus optional metadata. A "read any page" tool for AI Agents, using the same three-tier extractor as search.
+- **New operation: Instant Answer** — DuckDuckGo's official free, no-key Instant Answer API: direct answers, Wikipedia-style abstracts, definitions, and related topics.
+- **Page metadata for Fetch Page Content** — a new **Include Page Metadata** option adds `pageTitle`, `pageAuthor`, `pagePublished`, `pageExcerpt`, and `pageSiteName` to Web and News results when the page is an article.
+
+---
+
+## Notes
+
+- All three are **free, need no API key, and add no paid or external dependencies** (they reuse axios + the existing extractor and DuckDuckGo's own endpoints).
+- 🔒 The Extract Page Content operation fetches a third-party URL directly (like the opt-in Fetch Page Content). Instant Answer and search talk only to DuckDuckGo.
+
+## Compatibility
+
+- No breaking changes. The new operations and fields are additive; existing operations are unchanged.
+
+---
+
+## Validation
+
+- `tsc`, ESLint, full suite (249 tests across 12 suites), `npm run build:prod`, and `verify-build` all pass. Verified live in n8n 2.27.3 (both new operations + metadata, against real pages and the Instant Answer API).
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.9.0
+```
+
+---
+
 # v32.8.0 — Page Content Extraction for News Search
 
 **Release Date:** 2026-06-24

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -6,6 +6,7 @@ import {
   INodeExecutionData,
   INodeType,
   INodeTypeDescription,
+  IDataObject,
   NodeOperationError,
   NodeConnectionType,
 } from 'n8n-workflow';
@@ -57,7 +58,8 @@ import {
 import { buildSearchQuery, validateSearchOperators, OPERATOR_INFO, ISearchOperators } from './searchOperators';
 import { paginateWithVqd, DEFAULT_PAGINATION_CONFIG } from './vqdPagination';
 import { fallbackNewsSearch, fallbackVideoSearch } from './fallbackSearch';
-import { fetchPageContents } from './pageContent';
+import { fetchPageContent, fetchPageContents } from './pageContent';
+import { getInstantAnswer } from './instantAnswer';
 
 // Sleep for a fixed amount of time
 function sleep(ms: number): Promise<void> {
@@ -133,6 +135,7 @@ async function enrichWithPageContent(
     pageContentMaxResults?: number;
     pageContentMaxLength?: number;
     pageContentTimeout?: number;
+    includePageMetadata?: boolean;
   },
   debugMode: boolean,
   operation: string,
@@ -164,6 +167,13 @@ async function enrichWithPageContent(
     }
     if (pc.error) {
       r.json.pageContentError = pc.error;
+    }
+    if (pageOpts.includePageMetadata && pc.meta) {
+      if (pc.meta.title) r.json.pageTitle = pc.meta.title;
+      if (pc.meta.author) r.json.pageAuthor = pc.meta.author;
+      if (pc.meta.published) r.json.pagePublished = pc.meta.published;
+      if (pc.meta.excerpt) r.json.pageExcerpt = pc.meta.excerpt;
+      if (pc.meta.siteName) r.json.pageSiteName = pc.meta.siteName;
     }
   });
 
@@ -232,10 +242,106 @@ export class DuckDuckGo implements INodeType {
             value: DuckDuckGoOperation.SearchVideos,
             description: 'Find videos from various sources',
             action: 'Search for videos',
+          },
+          {
+            name: 'Extract Page Content',
+            value: DuckDuckGoOperation.ExtractContent,
+            description: 'Fetch any URL and extract its main text and metadata',
+            action: 'Extract page content from a URL',
+          },
+          {
+            name: 'Instant Answer',
+            value: DuckDuckGoOperation.InstantAnswer,
+            description: 'Get a direct answer, abstract, or definition from DuckDuckGo',
+            action: 'Get an instant answer',
           }
         ],
       },
 
+
+      // ----------------------------------------
+      // Extract Page Content Operation Parameters
+      // ----------------------------------------
+      {
+        displayName: 'URL',
+        name: 'url',
+        type: 'string',
+        required: true,
+        default: '',
+        description: 'The URL of the page to fetch and extract text from',
+        placeholder: 'https://example.com/article',
+        displayOptions: {
+          show: {
+            operation: [
+              DuckDuckGoOperation.ExtractContent,
+            ],
+          },
+        },
+      },
+      {
+        displayName: 'Options',
+        name: 'extractOptions',
+        type: 'collection',
+        placeholder: 'Add Option',
+        default: {},
+        displayOptions: {
+          show: {
+            operation: [
+              DuckDuckGoOperation.ExtractContent,
+            ],
+          },
+        },
+        options: [
+          {
+            displayName: 'Max Content Length',
+            name: 'pageContentMaxLength',
+            type: 'number',
+            default: 2000,
+            description: 'Maximum number of characters of extracted text to keep, or 0 for no limit',
+            typeOptions: {
+              minValue: 0,
+            },
+          },
+          {
+            displayName: 'Page Fetch Timeout',
+            name: 'pageContentTimeout',
+            type: 'number',
+            default: 8000,
+            description: 'Maximum time in milliseconds to wait for the page to load',
+            typeOptions: {
+              minValue: 1000,
+              maxValue: 60000,
+            },
+          },
+          {
+            displayName: 'Include Page Metadata',
+            name: 'includePageMetadata',
+            type: 'boolean',
+            default: false,
+            description: 'Whether to also return page metadata (title, author, published, excerpt, siteName) when the page is an article',
+          },
+        ],
+      },
+
+      // ----------------------------------------
+      // Instant Answer Operation Parameters
+      // ----------------------------------------
+      {
+        displayName: 'Query',
+        name: 'instantAnswerQuery',
+        type: 'string',
+        required: true,
+        default: '',
+        description: 'The term or question to get an instant answer for (e.g. a person, place, or concept)',
+        placeholder: 'e.g. DuckDuckGo',
+        displayOptions: {
+          show: {
+            operation: [
+              DuckDuckGoOperation.InstantAnswer,
+            ],
+          },
+        },
+      },
 
       // ----------------------------------------
       // Web Search Operation Parameters
@@ -378,6 +484,18 @@ export class DuckDuckGo implements INodeType {
               minValue: 1000,
               maxValue: 60000,
             },
+            displayOptions: {
+              show: {
+                fetchPageContent: [true],
+              },
+            },
+          },
+          {
+            displayName: 'Include Page Metadata',
+            name: 'includePageMetadata',
+            type: 'boolean',
+            default: false,
+            description: 'Whether to also add page metadata (pageTitle, pageAuthor, pagePublished, pageExcerpt, pageSiteName) when the page is an article',
             displayOptions: {
               show: {
                 fetchPageContent: [true],
@@ -812,6 +930,18 @@ export class DuckDuckGo implements INodeType {
               },
             },
           },
+          {
+            displayName: 'Include Page Metadata',
+            name: 'includePageMetadata',
+            type: 'boolean',
+            default: false,
+            description: 'Whether to also add page metadata (pageTitle, pageAuthor, pagePublished, pageExcerpt, pageSiteName) when the page is an article',
+            displayOptions: {
+              show: {
+                fetchPageContent: [true],
+              },
+            },
+          },
         ],
       },
 
@@ -1136,6 +1266,7 @@ export class DuckDuckGo implements INodeType {
             pageContentMaxResults?: number;
             pageContentMaxLength?: number;
             pageContentTimeout?: number;
+            includePageMetadata?: boolean;
           };
 
           // Enhanced query processing for better results
@@ -1570,6 +1701,7 @@ export class DuckDuckGo implements INodeType {
             pageContentMaxResults?: number;
             pageContentMaxLength?: number;
             pageContentTimeout?: number;
+            includePageMetadata?: boolean;
           };
 
           // Set up search options with correct API according to duck-duck-scrape documentation
@@ -2158,6 +2290,82 @@ export class DuckDuckGo implements INodeType {
 
             }
           }
+        }
+        else if (operation === DuckDuckGoOperation.ExtractContent) {
+          const url = this.getNodeParameter('url', itemIndex) as string;
+          if (!url || url.trim() === '') {
+            throw new NodeOperationError(
+              this.getNode(),
+              'URL is required for the Extract Page Content operation',
+              { itemIndex }
+            );
+          }
+
+          const extractOptions = this.getNodeParameter('extractOptions', itemIndex, {}) as {
+            pageContentMaxLength?: number;
+            pageContentTimeout?: number;
+            includePageMetadata?: boolean;
+          };
+
+          const pc = await fetchPageContent(url.trim(), {
+            maxLength: extractOptions.pageContentMaxLength ?? 2000,
+            timeout: extractOptions.pageContentTimeout ?? 8000,
+          });
+
+          const json: IDataObject = {
+            url: url.trim(),
+            content: pc.content,
+            sourceType: 'pageContent',
+          };
+          if (pc.truncated) {
+            json.pageContentTruncated = true;
+          }
+          if (pc.error) {
+            json.error = pc.error;
+          }
+          if (extractOptions.includePageMetadata && pc.meta) {
+            if (pc.meta.title) json.title = pc.meta.title;
+            if (pc.meta.author) json.author = pc.meta.author;
+            if (pc.meta.published) json.published = pc.meta.published;
+            if (pc.meta.excerpt) json.excerpt = pc.meta.excerpt;
+            if (pc.meta.siteName) json.siteName = pc.meta.siteName;
+          }
+
+          results = [{ json, pairedItem: { item: itemIndex } }];
+        }
+        else if (operation === DuckDuckGoOperation.InstantAnswer) {
+          const query = this.getNodeParameter('instantAnswerQuery', itemIndex) as string;
+          if (!query || query.trim() === '') {
+            throw new NodeOperationError(
+              this.getNode(),
+              'Query is required for the Instant Answer operation',
+              { itemIndex }
+            );
+          }
+
+          const ia = await getInstantAnswer(query.trim(), { timeout: 8000 });
+
+          const json: IDataObject = {
+            query: query.trim(),
+            heading: ia.heading,
+            abstract: ia.abstract,
+            abstractSource: ia.abstractSource,
+            abstractURL: ia.abstractURL,
+            answer: ia.answer,
+            answerType: ia.answerType,
+            definition: ia.definition,
+            definitionSource: ia.definitionSource,
+            definitionURL: ia.definitionURL,
+            image: ia.image,
+            type: ia.type,
+            relatedTopics: ia.relatedTopics,
+            sourceType: 'instantAnswer',
+          };
+          if (ia.error) {
+            json.error = ia.error;
+          }
+
+          results = [{ json, pairedItem: { item: itemIndex } }];
         }
         else {
           throw new NodeOperationError(

--- a/nodes/DuckDuckGo/__tests__/instantAnswer.test.ts
+++ b/nodes/DuckDuckGo/__tests__/instantAnswer.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for instantAnswer.ts — DuckDuckGo Instant Answer API client.
+ * axios is mocked; no real network calls.
+ */
+
+jest.mock('axios');
+
+import axios from 'axios';
+import { getInstantAnswer } from '../instantAnswer';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('instantAnswer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an error for an empty query without calling axios', async () => {
+    mockedAxios.get = jest.fn();
+    const r = await getInstantAnswer('   ');
+    expect(r.error).toBe('No query provided');
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('parses abstract, source, heading, type and makes the image absolute', async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue({
+      data: {
+        Heading: 'DuckDuckGo',
+        AbstractText: 'DuckDuckGo is an internet search engine.',
+        AbstractSource: 'Wikipedia',
+        AbstractURL: 'https://en.wikipedia.org/wiki/DuckDuckGo',
+        Image: '/i/abc.png',
+        Type: 'A',
+        RelatedTopics: [],
+      },
+    });
+    const r = await getInstantAnswer('duckduckgo');
+    expect(r.error).toBeUndefined();
+    expect(r.heading).toBe('DuckDuckGo');
+    expect(r.abstract).toContain('search engine');
+    expect(r.abstractSource).toBe('Wikipedia');
+    expect(r.type).toBe('A');
+    expect(r.image).toBe('https://duckduckgo.com/i/abc.png');
+  });
+
+  it('keeps already-absolute image URLs unchanged', async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue({ data: { Image: 'https://x.com/y.png', RelatedTopics: [] } });
+    const r = await getInstantAnswer('q');
+    expect(r.image).toBe('https://x.com/y.png');
+  });
+
+  it('captures a direct Answer (e.g. calculations)', async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue({ data: { Answer: '42', AnswerType: 'calc', RelatedTopics: [] } });
+    const r = await getInstantAnswer('6 * 7');
+    expect(r.answer).toBe('42');
+    expect(r.answerType).toBe('calc');
+  });
+
+  it('flattens both flat and nested (category) related topics', async () => {
+    mockedAxios.get = jest.fn().mockResolvedValue({
+      data: {
+        RelatedTopics: [
+          { Text: 'Topic A', FirstURL: 'https://a.com' },
+          { Name: 'Category', Topics: [{ Text: 'Sub B', FirstURL: 'https://b.com' }] },
+          { something: 'ignored' },
+        ],
+      },
+    });
+    const r = await getInstantAnswer('q');
+    expect(r.relatedTopics).toEqual([
+      { text: 'Topic A', url: 'https://a.com' },
+      { text: 'Sub B', url: 'https://b.com' },
+    ]);
+  });
+
+  it('reports a timeout error', async () => {
+    mockedAxios.get = jest.fn().mockRejectedValue({ code: 'ECONNABORTED' });
+    const r = await getInstantAnswer('q', { timeout: 1234 });
+    expect(r.error).toBe('Timed out after 1234ms');
+    expect(r.abstract).toBe('');
+  });
+
+  it('reports an HTTP error', async () => {
+    mockedAxios.get = jest.fn().mockRejectedValue({ response: { status: 500 } });
+    const r = await getInstantAnswer('q');
+    expect(r.error).toBe('HTTP 500');
+  });
+});

--- a/nodes/DuckDuckGo/__tests__/pageContent.test.ts
+++ b/nodes/DuckDuckGo/__tests__/pageContent.test.ts
@@ -83,11 +83,12 @@ describe('pageContent', () => {
         <footer>FOOTER_SHOULD_BE_REMOVED copyright 2026</footer>
       </body></html>`;
 
-      const text = extractWithReadability(html);
-      expect(text).not.toBeNull();
-      expect(text as string).toContain('reusable components');
-      expect(text as string).not.toContain('MENU_ITEM_SHOULD_BE_REMOVED');
-      expect(text as string).not.toContain('FOOTER_SHOULD_BE_REMOVED');
+      const result = extractWithReadability(html);
+      expect(result).not.toBeNull();
+      expect(result!.text).toContain('reusable components');
+      expect(result!.text).not.toContain('MENU_ITEM_SHOULD_BE_REMOVED');
+      expect(result!.text).not.toContain('FOOTER_SHOULD_BE_REMOVED');
+      expect(result!.meta.title).toContain('Understanding Widgets');
     });
 
     it('returns null for pages with too little content (caller falls back)', () => {
@@ -158,6 +159,7 @@ describe('pageContent', () => {
       expect(result.error).toBeUndefined();
       expect(result.content).toContain('interesting topic');
       expect(result.content).not.toContain('NAVBOILERPLATE');
+      expect(result.meta).toBeDefined();
     });
 
     it('extracts main text from an HTML response', async () => {

--- a/nodes/DuckDuckGo/instantAnswer.ts
+++ b/nodes/DuckDuckGo/instantAnswer.ts
@@ -1,0 +1,139 @@
+/**
+ * DuckDuckGo Instant Answer API client.
+ *
+ * Uses DuckDuckGo's official, free, no-key JSON endpoint
+ * (https://api.duckduckgo.com) to return direct answers, abstracts
+ * (Wikipedia-style summaries), definitions, and related topics for a query.
+ *
+ * No API key, no cost, no telemetry — same privacy posture as the rest of the
+ * node (requests go only to DuckDuckGo).
+ */
+
+import axios from 'axios';
+import { BROWSER_USER_AGENT } from './constants';
+
+export interface RelatedTopic {
+  text: string;
+  url: string;
+}
+
+export interface InstantAnswerResult {
+  heading: string;
+  abstract: string;
+  abstractSource: string;
+  abstractURL: string;
+  answer: string;
+  answerType: string;
+  definition: string;
+  definitionSource: string;
+  definitionURL: string;
+  image: string;
+  /** DuckDuckGo answer type: A=article, D=disambiguation, C=category, N=name, E=exclusive, ''=none. */
+  type: string;
+  relatedTopics: RelatedTopic[];
+  /** Present only when the request failed. */
+  error?: string;
+}
+
+export interface InstantAnswerOptions {
+  timeout?: number;
+}
+
+const DEFAULT_TIMEOUT = 8000;
+
+function emptyResult(): InstantAnswerResult {
+  return {
+    heading: '', abstract: '', abstractSource: '', abstractURL: '',
+    answer: '', answerType: '', definition: '', definitionSource: '',
+    definitionURL: '', image: '', type: '', relatedTopics: [],
+  };
+}
+
+/**
+ * Flatten DuckDuckGo's RelatedTopics, which may contain both flat topics
+ * ({ Text, FirstURL }) and grouped categories ({ Name, Topics: [...] }).
+ */
+function flattenRelatedTopics(raw: unknown): RelatedTopic[] {
+  if (!Array.isArray(raw)) return [];
+  const out: RelatedTopic[] = [];
+  for (const item of raw as any[]) {
+    if (item && typeof item.Text === 'string') {
+      out.push({ text: item.Text, url: typeof item.FirstURL === 'string' ? item.FirstURL : '' });
+    } else if (item && Array.isArray(item.Topics)) {
+      for (const sub of item.Topics) {
+        if (sub && typeof sub.Text === 'string') {
+          out.push({ text: sub.Text, url: typeof sub.FirstURL === 'string' ? sub.FirstURL : '' });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** Normalise a DuckDuckGo image path to an absolute URL. */
+function absoluteImage(image: unknown): string {
+  if (typeof image !== 'string' || image === '') return '';
+  return image.startsWith('http') ? image : `https://duckduckgo.com${image}`;
+}
+
+/**
+ * Query the DuckDuckGo Instant Answer API. Never throws: failures are reported
+ * via the `error` field.
+ */
+export async function getInstantAnswer(
+  query: string,
+  options: InstantAnswerOptions = {},
+): Promise<InstantAnswerResult> {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+
+  if (!query || typeof query !== 'string' || query.trim() === '') {
+    return { ...emptyResult(), error: 'No query provided' };
+  }
+
+  try {
+    const params = new URLSearchParams({
+      q: query,
+      format: 'json',
+      no_html: '1',
+      skip_disambig: '1',
+      t: 'n8n-nodes-duckduckgo-search',
+    });
+
+    const response = await axios.get(`https://api.duckduckgo.com/?${params.toString()}`, {
+      timeout,
+      responseType: 'json',
+      headers: {
+        'User-Agent': BROWSER_USER_AGENT,
+        'Accept': 'application/json',
+      },
+    });
+
+    const d: any = response.data || {};
+    return {
+      heading: d.Heading || '',
+      abstract: d.AbstractText || '',
+      abstractSource: d.AbstractSource || '',
+      abstractURL: d.AbstractURL || '',
+      answer: typeof d.Answer === 'string' ? d.Answer : (d.Answer ? JSON.stringify(d.Answer) : ''),
+      answerType: d.AnswerType || '',
+      definition: d.Definition || '',
+      definitionSource: d.DefinitionSource || '',
+      definitionURL: d.DefinitionURL || '',
+      image: absoluteImage(d.Image),
+      type: d.Type || '',
+      relatedTopics: flattenRelatedTopics(d.RelatedTopics),
+    };
+  } catch (error: any) {
+    let message: string;
+    if (error?.code === 'ECONNABORTED') {
+      message = `Timed out after ${timeout}ms`;
+    } else if (error?.response?.status) {
+      message = `HTTP ${error.response.status}`;
+    } else if (error?.code) {
+      message = String(error.code);
+    } else {
+      message = error instanceof Error ? error.message : 'Unknown error';
+    }
+    return { ...emptyResult(), error: message };
+  }
+}

--- a/nodes/DuckDuckGo/pageContent.ts
+++ b/nodes/DuckDuckGo/pageContent.ts
@@ -26,11 +26,26 @@ export interface PageContentOptions {
   maxBytes?: number;
 }
 
+export interface PageMeta {
+  /** Article title. */
+  title?: string;
+  /** Author / byline. */
+  author?: string;
+  /** Short excerpt or description. */
+  excerpt?: string;
+  /** Published time as reported by the page. */
+  published?: string;
+  /** Site name. */
+  siteName?: string;
+}
+
 export interface PageContentResult {
   /** Extracted (and possibly truncated) main text. Empty string on failure. */
   content: string;
   /** True when the text was cut to fit maxLength. */
   truncated: boolean;
+  /** Article metadata, present only when Readability identified an article. */
+  meta?: PageMeta;
   /** Present only when the page could not be fetched or parsed. */
   error?: string;
 }
@@ -155,12 +170,19 @@ function normaliseWhitespace(s: string): string {
  */
 const MIN_READABLE_LENGTH = 200;
 
+export interface ReadabilityResult {
+  /** Clean, normalised article text. */
+  text: string;
+  /** Article metadata extracted alongside the text. */
+  meta: PageMeta;
+}
+
 /**
- * Extract clean article text using Mozilla Readability over a linkedom DOM.
- * Returns null when no substantial article is found, so the caller can fall
- * back to the heuristic extractor. Never throws.
+ * Extract clean article text and metadata using Mozilla Readability over a
+ * linkedom DOM. Returns null when no substantial article is found, so the
+ * caller can fall back to the heuristic extractor. Never throws.
  */
-export function extractWithReadability(html: string): string | null {
+export function extractWithReadability(html: string): ReadabilityResult | null {
   if (!html) return null;
   try {
     const { document } = parseHTML(html);
@@ -169,7 +191,14 @@ export function extractWithReadability(html: string): string | null {
     const article = new Readability(document as any).parse();
     if (article && article.textContent && (article.length ?? 0) >= MIN_READABLE_LENGTH) {
       const text = normaliseWhitespace(article.textContent);
-      return text.length > 0 ? text : null;
+      if (text.length === 0) return null;
+      const meta: PageMeta = {};
+      if (article.title) meta.title = article.title;
+      if (article.byline) meta.author = article.byline;
+      if (article.excerpt) meta.excerpt = article.excerpt;
+      if (article.publishedTime) meta.published = article.publishedTime;
+      if (article.siteName) meta.siteName = article.siteName;
+      return { text, meta };
     }
     return null;
   } catch {
@@ -235,14 +264,19 @@ export async function fetchPageContent(
     }
 
     const html = typeof response.data === 'string' ? response.data : String(response.data ?? '');
-    // Three-tier extraction: Readability for clean article text; a linkedom DOM
-    // heuristic (drops menus by link density) when Readability finds no article;
-    // and the regex heuristic as a last resort if DOM parsing fails.
-    const text = extractWithReadability(html)
-      ?? extractWithDomHeuristic(html)
-      ?? extractMainText(html);
-    const { text: finalText, truncated } = truncateText(text, maxLength);
-    return { content: finalText, truncated };
+    // Three-tier extraction: Readability (with metadata) for clean article text;
+    // a linkedom DOM heuristic (drops menus by link density) when Readability
+    // finds no article; and the regex heuristic as a last resort.
+    const readable = extractWithReadability(html);
+    const rawText = readable
+      ? readable.text
+      : (extractWithDomHeuristic(html) ?? extractMainText(html));
+    const { text: finalText, truncated } = truncateText(rawText, maxLength);
+    const result: PageContentResult = { content: finalText, truncated };
+    if (readable && Object.keys(readable.meta).length > 0) {
+      result.meta = readable.meta;
+    }
+    return result;
   } catch (error: any) {
     let message: string;
     if (error?.code === 'ECONNABORTED') {

--- a/nodes/DuckDuckGo/types.ts
+++ b/nodes/DuckDuckGo/types.ts
@@ -23,6 +23,8 @@ export enum DuckDuckGoOperation {
   SearchImages = 'searchImages',
   SearchNews = 'searchNews',
   SearchVideos = 'searchVideos',
+  ExtractContent = 'extractContent',
+  InstantAnswer = 'instantAnswer',
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.8.0",
+  "version": "32.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.8.0",
+      "version": "32.9.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.8.0",
+  "version": "32.9.0",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
   "version": "32.8.0",
-  "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
+  "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",
     "n8n",


### PR DESCRIPTION
Three **free, no-key, no-new-dependency** additions that turn the node into a fuller research toolkit.

## What's new
- **Operation: Extract Page Content** — fetch any URL → main text (`content`) + optional metadata, via the existing three-tier extractor (Readability → DOM heuristic → regex). A "read any page" tool for AI Agents.
- **Operation: Instant Answer** — DuckDuckGo's official free, no-key Instant Answer API → `answer`, `abstract`, `definition`, `relatedTopics`, image, source, type.
- **Page metadata** — new **Include Page Metadata** sub-option on Web/News Fetch Page Content adds `pageTitle` / `pageAuthor` / `pagePublished` / `pageExcerpt` / `pageSiteName`.

## Implementation
- `extractWithReadability` now returns text **+ metadata**; `fetchPageContent` surfaces it.
- New `instantAnswer.ts` module (axios → `api.duckduckgo.com`, parses abstract/answer/definition/relatedTopics).
- Two new operations wired into the dropdown + execute; shared `enrichWithPageContent` extended with metadata.
- No new dependencies (reuses axios + existing extractor + DuckDuckGo's endpoints).

## Validation
`tsc` clean · ESLint clean · **249 tests / 12 suites** (7 new for instantAnswer) · `build:prod` + `verify-build` pass · **verified live in n8n 2.27.3**: Extract returned full Wikipedia text + metadata; Instant Answer returned a clean abstract + related topics.

Released as **v32.9.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)