### PR TITLE
chore(release): 32.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [32.9.1] - 2026-06-24
+
+### Changed
+
+- **Dependencies:** bumped `axios` from 1.13.5 to 1.18.1 (bug and security fixes).
+- **CI:** updated GitHub Actions — `actions/checkout` 4→7, `actions/setup-node` 4→6, and `softprops/action-gh-release` 2→3 (clears the deprecated Node 20 runner warnings). No change to the published package or runtime behaviour.
+
+---
+
 ## [32.9.0] - 2026-06-24
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,30 @@
+# v32.9.1 — Maintenance (dependencies & CI)
+
+**Release Date:** 2026-06-24
+
+A small maintenance release. No user-facing feature or behaviour changes.
+
+---
+
+## Highlights
+
+- **Dependencies:** `axios` bumped 1.13.5 → 1.18.1 (bug and security fixes).
+- **CI:** GitHub Actions updated — `actions/checkout` 4→7, `actions/setup-node` 4→6, and `softprops/action-gh-release` 2→3, clearing the deprecated Node 20 runner warnings.
+
+## Compatibility
+
+- No breaking changes; no change to the published node's runtime behaviour.
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.9.1
+```
+
+---
+
 # v32.9.0 — Page Metadata, Extract-from-URL, and Instant Answers
 
 **Release Date:** 2026-06-24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.9.0",
+  "version": "32.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.9.0",
+      "version": "32.9.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.9.0",
+  "version": "32.9.1",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Small maintenance release wrapping up the dependency/CI updates.

- **deps:** `axios` 1.13.5 → 1.18.1 (bug/security fixes, merged in #19)
- **ci:** `actions/checkout` 4→7, `actions/setup-node` 4→6, `softprops/action-gh-release` 2→3 (clears the deprecated Node 20 runner warnings)

No change to the published package's runtime behaviour. 249 tests / build / verify all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)