### PR TITLE
chore(release): 32.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [32.9.2] - 2026-06-25
+
+### Changed
+
+- **Dependencies:** updated `@mozilla/readability` 0.5.0 → 0.6.0, the engine behind Fetch Page Content and the Extract Page Content operation.
+- **Tooling:** migrated ESLint to the flat-config format (`eslint.config.js`, ESLint 9), and the main node file is now linted. This tidied parameter descriptions (consistent final periods, a "Whether" boolean description) and the node input/output declarations — no runtime behaviour change.
+- **Dev dependencies:** glob 13.0.6, n8n-core 2.16.1, prettier 3.8.4, rimraf 6.1.3, ts-jest 29.4.11.
+
+---
+
 ## [32.9.1] - 2026-06-24
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,31 @@
+# v32.9.2 — Maintenance (readability 0.6, ESLint flat config, deps)
+
+**Release Date:** 2026-06-25
+
+A maintenance release. No new features and no change to runtime search behaviour.
+
+---
+
+## Highlights
+
+- **`@mozilla/readability` 0.5 → 0.6** — the engine behind Fetch Page Content and the Extract Page Content operation.
+- **ESLint flat-config migration** (ESLint 9); the main node file is now linted, which tidied parameter descriptions and input/output declarations.
+- **Dev-dependency refresh:** glob 13, n8n-core 2.16.1, prettier 3.8.4, rimraf 6.1.3, ts-jest 29.4.11.
+
+## Compatibility
+
+- No breaking changes; existing workflows are unaffected.
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.9.2
+```
+
+---
+
 # v32.9.1 — Maintenance (dependencies & CI)
 
 **Release Date:** 2026-06-24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.9.1",
+  "version": "32.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.9.1",
+      "version": "32.9.2",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.9.1",
+  "version": "32.9.2",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Maintenance release bundling the merged dependency + tooling updates.

- **deps:** `@mozilla/readability` 0.5.0 → 0.6.0 (page-content / Extract Page Content extractor) — #27
- **tooling:** ESLint flat-config migration (ESLint 9); the main node file is now linted (tidied descriptions + input/output decls) — #25
- **dev-deps:** glob 13, n8n-core 2.16.1, prettier 3.8.4, rimraf 6.1.3, ts-jest 29.4.11 — #26

No new features, no runtime behaviour change. lint / build:prod / verify-build / 249 tests all green on merged main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)