### PR TITLE
fix: detect DuckDuckGo's bot-detection challenge instead of returning no results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ npm-debug.log*
 yarn.lock
 *.tgz
 .vscode/launch.json
+
+# Internal working plan — kept local, not published
+PROJECT_PLAN.md

--- a/nodes/DuckDuckGo/__tests__/challengeDetection.test.ts
+++ b/nodes/DuckDuckGo/__tests__/challengeDetection.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for challengeDetection.ts and its integration into the search paths.
+ *
+ * Covers the failure this was written for: DuckDuckGo answers a blocked client
+ * with a human-verification page served as HTTP 202, which axios accepts as a
+ * success, which the parser then reads as "no results". The user saw an empty
+ * result set and no error.
+ */
+
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { isChallengePage, createChallengeError, assertNotChallenged } from '../challengeDetection';
+import { DuckDuckGoError, DuckDuckGoErrorType, ErrorSeverity } from '../errors';
+import { directWebSearch, directImageSearch } from '../directSearch';
+import { fallbackWebSearch } from '../fallbackSearch';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** DuckDuckGo's anti-bot challenge page, reduced to the markers that identify it. */
+const CHALLENGE_HTML = `<!DOCTYPE html>
+<html lang="en"><head><title>DuckDuckGo</title>
+<script src="/dist/anomaly.js"></script></head>
+<body>
+<div id="anomaly-modal" class="anomaly-modal">
+  <div class="anomaly-modal__box">
+    <p>Please complete the following challenge to confirm this search was made by a human.</p>
+  </div>
+</div>
+</body></html>`;
+
+/** A normal results page — must never be classified as a challenge. */
+const RESULTS_HTML = `<!DOCTYPE html>
+<html lang="en"><body><div id="links">
+<div class="result results_links results_links_deep web-result">
+  <h2 class="result__title">
+    <a class="result__a" href="https://example.com/a">Example</a>
+  </h2>
+  <a class="result__snippet" href="https://example.com/a">Snippet text.</a>
+</div>
+</div></body></html>`;
+
+/** Genuine empty result set: no result blocks and no challenge markers. */
+const NO_RESULTS_HTML = `<!DOCTYPE html>
+<html lang="en"><body><center id="lite_wrapper">
+  <form id="search_form" action="/html/" method="post">
+    <input type="text" name="q" value="xzqwerty99zz" />
+  </form>
+</center></body></html>`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Pure detector
+// ---------------------------------------------------------------------------
+
+describe('isChallengePage', () => {
+  it('detects the challenge page', () => {
+    expect(isChallengePage(CHALLENGE_HTML)).toBe(true);
+  });
+
+  it.each([
+    ['modal id', '<div id="anomaly-modal"></div>'],
+    ['internal flag', '{"anomalyDetectionBlock":true}'],
+    ['challenge script', '<script src="/anomaly.js"></script>'],
+    ['bot_challenge flag', 'var page = "bot_challenge";'],
+    ['challenge copy', 'confirm this search was made by a human'],
+  ])('detects a challenge by its %s', (_label, body) => {
+    expect(isChallengePage(body)).toBe(true);
+  });
+
+  it('matches markers regardless of case', () => {
+    expect(isChallengePage('<DIV ID="ANOMALY-MODAL">')).toBe(true);
+  });
+
+  it('does not flag a normal results page', () => {
+    expect(isChallengePage(RESULTS_HTML)).toBe(false);
+  });
+
+  it('does not flag a genuine no-results page', () => {
+    expect(isChallengePage(NO_RESULTS_HTML)).toBe(false);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['a parsed JSON object', { results: [] }],
+  ])('returns false for %s', (_label, body) => {
+    expect(isChallengePage(body)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error shape
+// ---------------------------------------------------------------------------
+
+describe('createChallengeError', () => {
+  it('produces a typed, non-retryable error carrying the status code', () => {
+    const error = createChallengeError('web search', 202);
+
+    expect(error).toBeInstanceOf(DuckDuckGoError);
+    expect(error.errorType).toBe(DuckDuckGoErrorType.BOT_CHALLENGE);
+    expect(error.statusCode).toBe(202);
+    expect(error.severity).toBe(ErrorSeverity.MEDIUM);
+    // Retrying immediately would only add load to an IP that is already blocked.
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('gives the user an actionable message', () => {
+    const message = createChallengeError('web search').userMessage.toLowerCase();
+
+    expect(message).toContain('bot-detection challenge');
+    expect(message).toContain('ip address');
+    expect(message).toContain('wait');
+  });
+});
+
+describe('assertNotChallenged', () => {
+  it('throws for a challenge page', () => {
+    expect(() => assertNotChallenged(CHALLENGE_HTML, 202, 'web search')).toThrow(DuckDuckGoError);
+  });
+
+  it('is a no-op for anything else', () => {
+    expect(() => assertNotChallenged(RESULTS_HTML, 200, 'web search')).not.toThrow();
+    expect(() => assertNotChallenged(undefined, 200, 'web search')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — the paths that previously failed silently
+// ---------------------------------------------------------------------------
+
+describe('directWebSearch challenge handling', () => {
+  it('throws instead of returning an empty result set when challenged (HTTP 202)', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ status: 202, data: CHALLENGE_HTML });
+
+    await expect(directWebSearch('anything')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+  });
+
+  it('detects a challenge served with HTTP 200 as well', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ status: 200, data: CHALLENGE_HTML });
+
+    await expect(directWebSearch('anything')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+  });
+
+  it('still returns an empty result set for a genuine HTTP 202 no-results page', async () => {
+    // Regression guard: the challenge check must not turn a real empty result
+    // set into an error, including when the page is large.
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 202,
+      data: NO_RESULTS_HTML + ' '.repeat(5000),
+    });
+
+    const output = await directWebSearch('xzqwerty99zz totally made up query');
+
+    expect(output.results).toHaveLength(0);
+  });
+
+  it('does not misclassify a page that returns real results', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ status: 200, data: RESULTS_HTML });
+
+    const output = await directWebSearch('example');
+
+    expect(output.results).toHaveLength(1);
+  });
+});
+
+describe('directImageSearch challenge handling', () => {
+  it('names the challenge rather than reporting a missing VQD token', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 202, data: CHALLENGE_HTML });
+
+    await expect(directImageSearch('cats')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+  });
+});
+
+describe('fallbackWebSearch challenge handling', () => {
+  it('reports a challenge instead of masquerading as "no results"', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 202, data: CHALLENGE_HTML });
+
+    const response = await fallbackWebSearch('anything');
+
+    expect(response.challenged).toBe(true);
+    expect(response.success).toBe(false);
+    expect(response.results).toHaveLength(0);
+    expect(response.error).toContain('bot-detection challenge');
+  });
+
+  it('leaves a genuine empty result set reported as success', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 202, data: NO_RESULTS_HTML });
+
+    const response = await fallbackWebSearch('xzqwerty99zz');
+
+    expect(response.challenged).toBeUndefined();
+    expect(response.success).toBe(true);
+    expect(response.noResults).toBe(true);
+  });
+});

--- a/nodes/DuckDuckGo/challengeDetection.ts
+++ b/nodes/DuckDuckGo/challengeDetection.ts
@@ -1,0 +1,81 @@
+/**
+ * Detection of DuckDuckGo's anti-bot challenge ("anomaly") page.
+ *
+ * When DuckDuckGo decides a client is automated it answers with a
+ * human-verification page instead of results. Two properties make that
+ * dangerous for an HTML client:
+ *
+ *   1. It is served with HTTP 202, which axios treats as success, so the page
+ *      flows straight into the result parser.
+ *   2. The parser simply finds no result blocks, so the caller sees an empty
+ *      result set and no error — the failure is silent.
+ *
+ * The block is scoped to the requesting IP (not to the host), lasts tens of
+ * minutes, and survives a change of User-Agent, so retrying immediately or
+ * falling back to a sibling DuckDuckGo host only adds load. Callers should
+ * surface it rather than mask it as "no results".
+ *
+ * Detection is applied only where parsing already yielded zero results. A
+ * response that produced real results was self-evidently not a challenge, so
+ * marker text appearing inside a result snippet can never trigger a false
+ * positive.
+ */
+
+import { DuckDuckGoError, DuckDuckGoErrorType } from './errors';
+
+/**
+ * Substrings identifying the challenge page. Each is structural (element id,
+ * script path, internal flag) or verbatim challenge copy; none occur in
+ * ordinary result markup.
+ */
+const CHALLENGE_MARKERS: readonly string[] = [
+  'anomaly-modal',
+  'anomalydetectionblock',
+  'anomaly.js',
+  'bot_challenge',
+  'confirm this search was made by a human',
+  'please complete the following challenge',
+];
+
+/**
+ * True when a response body is DuckDuckGo's challenge page.
+ *
+ * Pure and side-effect free. Non-string bodies (e.g. parsed JSON) are never
+ * challenge pages and return false.
+ */
+export function isChallengePage(body: unknown): boolean {
+  if (typeof body !== 'string' || body.length === 0) {
+    return false;
+  }
+  const haystack = body.toLowerCase();
+  return CHALLENGE_MARKERS.some((marker) => haystack.includes(marker));
+}
+
+/**
+ * Build the error used for a detected challenge. Centralised so the wording
+ * stays identical wherever a challenge surfaces.
+ *
+ * @param operation - Human-readable operation name, used in the technical message.
+ * @param statusCode - HTTP status the challenge arrived with (typically 202).
+ */
+export function createChallengeError(operation: string, statusCode?: number): DuckDuckGoError {
+  return new DuckDuckGoError(
+    `DuckDuckGo returned a bot-detection challenge instead of ${operation} results.`,
+    DuckDuckGoErrorType.BOT_CHALLENGE,
+    { statusCode },
+  );
+}
+
+/**
+ * Throw a descriptive error when the body is a challenge page; otherwise do
+ * nothing. Call this at the point where zero results were parsed.
+ */
+export function assertNotChallenged(
+  body: unknown,
+  statusCode: number | undefined,
+  operation: string,
+): void {
+  if (isChallengePage(body)) {
+    throw createChallengeError(operation, statusCode);
+  }
+}

--- a/nodes/DuckDuckGo/directSearch.ts
+++ b/nodes/DuckDuckGo/directSearch.ts
@@ -5,6 +5,8 @@
 
 import axios from 'axios';
 import { BROWSER_USER_AGENT } from './constants';
+import { assertNotChallenged } from './challengeDetection';
+import { DuckDuckGoError } from './errors';
 
 /**
  * Clean text by removing HTML entities and normalizing whitespace
@@ -163,17 +165,23 @@ export async function directWebSearch(query: string, options: {
       }
     }
 
-    // If no result blocks were found, distinguish legitimate no-results from parser failure.
-    // DuckDuckGo returns HTTP 202 for genuine no-results pages; HTTP 200 with a large HTML
-    // body but zero parseable blocks means the page structure has likely changed.
+    // Nothing parsed — establish why before returning an empty set. This is the
+    // only point at which a challenge page can be detected without risking a
+    // false positive on marker text appearing inside a real result.
     if (results.length === 0 && resultSections.length === 1) {
+      // DuckDuckGo serves its bot-detection page with HTTP 202 — the same status
+      // as a genuine no-results page — so the status alone cannot tell them apart.
+      // Inspecting the body first stops an IP-level block from being reported as
+      // an ordinary empty result set, which is how it used to fail silently.
+      assertNotChallenged(html, response.status, 'web search');
+
       if (response.status === 200 && html.length > 1000) {
         throw new Error(
           'DuckDuckGo web search response could not be parsed. ' +
           'The page structure may have changed. Please try again later.'
         );
       }
-      // HTTP 202 = genuine no-results page. Return empty.
+      // HTTP 202 without challenge markers = genuine no-results page. Return empty.
     }
 
     return { results };
@@ -239,6 +247,10 @@ export async function directImageSearch(query: string, options: {
         timeout: 15000,
       });
 
+      // A challenge page carries no VQD. Detect it first so the cause is named
+      // instead of surfacing as a misleading "token could not be extracted".
+      assertNotChallenged(response.data, response.status, 'image search');
+
       const vqdMatch = response.data.match(/vqd=([\d-]+)/);
       const extracted = vqdMatch ? vqdMatch[1] : null;
 
@@ -296,6 +308,12 @@ export async function directImageSearch(query: string, options: {
     return { results, vqd };
   } catch (error) {
     console.error('Direct image search error:', error.message);
+
+    // Preserve typed errors (e.g. the bot-challenge error) rather than
+    // flattening them into a generic message and losing their guidance.
+    if (error instanceof DuckDuckGoError) {
+      throw error;
+    }
 
     if (error.code === 'ECONNABORTED') {
       throw new Error('Image search request timed out. Please try again.');

--- a/nodes/DuckDuckGo/errors.ts
+++ b/nodes/DuckDuckGo/errors.ts
@@ -21,6 +21,7 @@ export enum DuckDuckGoErrorType {
   API_ERROR = 'API_ERROR',
   RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
   TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
+  BOT_CHALLENGE = 'BOT_CHALLENGE',
   SERVER_ERROR = 'SERVER_ERROR',
   BAD_GATEWAY = 'BAD_GATEWAY',
   SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE',
@@ -97,6 +98,7 @@ export class DuckDuckGoError extends Error {
         return ErrorSeverity.HIGH;
       case DuckDuckGoErrorType.RATE_LIMIT_EXCEEDED:
       case DuckDuckGoErrorType.TOO_MANY_REQUESTS:
+      case DuckDuckGoErrorType.BOT_CHALLENGE:
       case DuckDuckGoErrorType.TIMEOUT:
         return ErrorSeverity.MEDIUM;
       case DuckDuckGoErrorType.INVALID_INPUT:
@@ -120,6 +122,10 @@ export class DuckDuckGoError extends Error {
       case DuckDuckGoErrorType.GATEWAY_TIMEOUT:
       case DuckDuckGoErrorType.VQD_TOKEN_ERROR:
         return true;
+      // A challenge is scoped to the requesting IP and lasts tens of minutes.
+      // Retrying immediately only adds load and prolongs the block.
+      case DuckDuckGoErrorType.BOT_CHALLENGE:
+        return false;
       default:
         return false;
     }
@@ -141,6 +147,11 @@ export class DuckDuckGoError extends Error {
         return 'DuckDuckGo servers are temporarily unavailable. Please try again later.';
       case DuckDuckGoErrorType.VQD_TOKEN_ERROR:
         return 'Search session expired. The search will be retried automatically.';
+      case DuckDuckGoErrorType.BOT_CHALLENGE:
+        return 'DuckDuckGo served a bot-detection challenge instead of results. This blocks the '
+          + 'IP address your n8n instance sends requests from, typically for tens of minutes. '
+          + 'Wait before retrying, and reduce how frequently this node runs — shared or cloud '
+          + 'IP addresses are affected sooner.';
       case DuckDuckGoErrorType.INVALID_INPUT:
         return `Invalid input: ${originalMessage}`;
       case DuckDuckGoErrorType.RESULTS_PARSING_ERROR:

--- a/nodes/DuckDuckGo/fallbackSearch.ts
+++ b/nodes/DuckDuckGo/fallbackSearch.ts
@@ -8,6 +8,7 @@ import { SearchOptions } from 'duck-duck-scrape';
 
 import axios from 'axios';
 import { BROWSER_USER_AGENT } from './constants';
+import { isChallengePage, createChallengeError } from './challengeDetection';
 
 export interface FallbackSearchResult {
   title: string;
@@ -21,6 +22,8 @@ export interface FallbackSearchResponse {
   results: FallbackSearchResult[];
   vqd?: string;
   error?: string;
+  /** True when DuckDuckGo answered with its bot-detection challenge page. */
+  challenged?: boolean;
 }
 
 /**
@@ -169,6 +172,19 @@ export async function fallbackWebSearch(
 
     // Parse results using regex instead of cheerio
     const results = parseSearchResultsFromHTML(response.data);
+
+    // A challenge page parses to zero results. Report it instead of letting it
+    // masquerade as "no results": the block is scoped to this IP, so retrying
+    // another DuckDuckGo host would only add load and prolong it.
+    if (results.length === 0 && isChallengePage(response.data)) {
+      return {
+        success: false,
+        noResults: true,
+        results: [],
+        challenged: true,
+        error: createChallengeError('fallback search', response.status).userMessage,
+      };
+    }
 
     // Check if no results found
     const noResultsIndicator = response.data.includes('no-results') || results.length === 0;


### PR DESCRIPTION
## Root cause

DuckDuckGo answers a blocked client with a human-verification page served as **HTTP 202**. axios treats 2xx as success, the parser then finds no result blocks, and the caller received **an empty result set with no error at all**.

This is the root cause behind issues #7 ("No results returned from Web Search") and #8 ("returns empty results after 2 or 3 executions").

`directSearch.ts` additionally encoded the assumption that *"HTTP 202 = genuine no-results page"* — which is exactly what swallowed the challenge, since DuckDuckGo uses 202 for **both**. The status alone cannot separate them, so the body is now inspected first.

## Changes

- **New `challengeDetection.ts`** — a pure, unit-tested detector plus a shared typed error. Detection runs **only where parsing already yielded zero results**, so marker text inside a real result can never cause a false positive.
- **New `DuckDuckGoErrorType.BOT_CHALLENGE`** with an actionable user message. Deliberately **not retryable**: the block is IP-scoped and lasts tens of minutes, so an immediate retry only prolongs it.
- **Web and image search** now throw the typed error. Image search previously reported a misleading *"VQD could not be extracted"*.
- **News/video fallback** reports `challenged: true` instead of masquerading as "no results", so an IP-level block is no longer hidden.

## Verification

- A genuine HTTP 202 no-results page (including a large one) still returns an empty set — covered by an explicit regression test.
- `tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **273 tests / 13 suites** pass (24 new, none broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)