### PR TITLE
fix: refuse private and non-HTTP(S) addresses when fetching page content

### DIFF
--- a/nodes/DuckDuckGo/__tests__/urlGuard.test.ts
+++ b/nodes/DuckDuckGo/__tests__/urlGuard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for urlGuard.ts and its enforcement inside fetchPageContent.
+ *
+ * The node is exposed to AI agents (usableAsTool) and fetches a caller-supplied
+ * URL, so the URL is untrusted input. Without the guard the n8n host could be
+ * made to read addresses only it can reach — its own API, cloud metadata, or
+ * internal services — and hand the body back to the model.
+ */
+
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { isBlockedHost, getUrlBlockReason, isFetchableUrl } from '../urlGuard';
+import { fetchPageContent } from '../pageContent';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isBlockedHost', () => {
+  it.each([
+    ['localhost', 'localhost'],
+    ['a .localhost subdomain (RFC 6761)', 'api.localhost'],
+    ['IPv4 loopback', '127.0.0.1'],
+    ['anywhere in 127.0.0.0/8', '127.1.2.3'],
+    ['IPv6 loopback', '::1'],
+    ['bracketed IPv6 loopback', '[::1]'],
+    ['unspecified address', '0.0.0.0'],
+    ['cloud metadata', '169.254.169.254'],
+    ['RFC1918 10/8', '10.0.0.5'],
+    ['RFC1918 172.16/12', '172.20.10.1'],
+    ['RFC1918 192.168/16', '192.168.1.1'],
+    ['CGNAT 100.64/10', '100.100.0.1'],
+    ['IPv6 link-local', 'fe80::1'],
+    ['IPv6 unique-local', 'fd00::1'],
+    ['IPv4-mapped loopback', '::ffff:127.0.0.1'],
+  ])('blocks %s', (_label, host) => {
+    expect(isBlockedHost(host)).toBe(true);
+  });
+
+  it.each([
+    ['a normal domain', 'example.com'],
+    ['a subdomain', 'en.wikipedia.org'],
+    ['a public IPv4', '8.8.8.8'],
+    ['172.15 (just outside RFC1918)', '172.15.0.1'],
+    ['172.32 (just outside RFC1918)', '172.32.0.1'],
+    ['a public IPv6', '2606:4700:4700::1111'],
+  ])('allows %s', (_label, host) => {
+    expect(isBlockedHost(host)).toBe(false);
+  });
+});
+
+describe('getUrlBlockReason', () => {
+  it('accepts ordinary http and https URLs', () => {
+    expect(getUrlBlockReason('https://example.com/article')).toBeNull();
+    expect(getUrlBlockReason('http://example.com/article')).toBeNull();
+    expect(isFetchableUrl('https://example.com')).toBe(true);
+  });
+
+  it.each([
+    ['file', 'file:///etc/passwd'],
+    ['data', 'data:text/html,<h1>hi</h1>'],
+    ['ftp', 'ftp://example.com/x'],
+    ['javascript', 'javascript:alert(1)'],
+  ])('refuses the %s scheme', (_label, url) => {
+    expect(getUrlBlockReason(url)).toContain('non-HTTP(S)');
+  });
+
+  it.each([
+    ["n8n's own API", 'http://127.0.0.1:5678/rest/workflows'],
+    ['cloud instance metadata', 'http://169.254.169.254/latest/meta-data/'],
+    ['an internal service', 'http://192.168.1.1/admin'],
+    ['localhost by name', 'http://localhost:5678/'],
+  ])('refuses %s', (_label, url) => {
+    expect(getUrlBlockReason(url)).toContain('private, loopback or link-local');
+  });
+
+  it.each([
+    ['a missing URL', undefined],
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+    ['a non-string', 42],
+  ])('rejects %s', (_label, url) => {
+    expect(getUrlBlockReason(url)).toBe('No URL to fetch');
+  });
+
+  it('rejects an unparseable URL', () => {
+    expect(getUrlBlockReason('not a url')).toBe('Invalid URL');
+  });
+});
+
+describe('fetchPageContent URL enforcement', () => {
+  it('refuses a loopback URL without making a request', async () => {
+    const result = await fetchPageContent('http://127.0.0.1:5678/rest/workflows');
+
+    expect(result.content).toBe('');
+    expect(result.error).toContain('private, loopback or link-local');
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('refuses the cloud metadata address without making a request', async () => {
+    const result = await fetchPageContent('http://169.254.169.254/latest/meta-data/');
+
+    expect(result.error).toContain('private, loopback or link-local');
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('refuses a non-HTTP scheme without making a request', async () => {
+    const result = await fetchPageContent('file:///etc/passwd');
+
+    expect(result.error).toContain('non-HTTP(S)');
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('still fetches an ordinary public URL', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+      data: `<html><body><article>
+        <p>A sufficiently long article paragraph so that the extractor treats this as
+        real content rather than boilerplate navigation, with enough words to pass the
+        minimum length threshold used before trusting the parsed result.</p>
+        <p>A second paragraph keeps the extracted article comfortably above that
+        threshold so the assertion below is stable.</p>
+      </article></body></html>`,
+    });
+
+    const result = await fetchPageContent('https://example.com/article');
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(result.error).toBeUndefined();
+    expect(result.content.length).toBeGreaterThan(0);
+  });
+
+  it('registers a beforeRedirect hook that rejects a private redirect target', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+      data: '<html><body><p>ok</p></body></html>',
+    });
+
+    await fetchPageContent('https://example.com/article');
+
+    const config = mockedAxios.get.mock.calls[0][1] as any;
+    expect(typeof config.beforeRedirect).toBe('function');
+
+    // A redirect to an internal address must abort the chain.
+    expect(() => config.beforeRedirect({ protocol: 'http:', hostname: '169.254.169.254' }))
+      .toThrow(/Refused to follow a redirect/);
+    expect(() => config.beforeRedirect({ protocol: 'http:', hostname: '127.0.0.1' }))
+      .toThrow(/Refused to follow a redirect/);
+    // A redirect to another public host is fine.
+    expect(() => config.beforeRedirect({ protocol: 'https:', hostname: 'example.org' }))
+      .not.toThrow();
+  });
+});

--- a/nodes/DuckDuckGo/pageContent.ts
+++ b/nodes/DuckDuckGo/pageContent.ts
@@ -16,6 +16,7 @@ import axios from 'axios';
 import { Readability } from '@mozilla/readability';
 import { parseHTML } from 'linkedom';
 import { BROWSER_USER_AGENT } from './constants';
+import { getUrlBlockReason, isBlockedHost } from './urlGuard';
 
 export interface PageContentOptions {
   /** Per-request timeout in milliseconds. */
@@ -240,8 +241,11 @@ export async function fetchPageContent(
   const maxLength = options.maxLength ?? DEFAULTS.maxLength;
   const maxBytes = options.maxBytes ?? DEFAULTS.maxBytes;
 
-  if (!url || typeof url !== 'string') {
-    return { content: '', truncated: false, error: 'No URL to fetch' };
+  // The URL is untrusted input: with usableAsTool an AI agent chooses it, and the
+  // agent can be steered by text inside the results this node itself returned.
+  const blockReason = getUrlBlockReason(url);
+  if (blockReason) {
+    return { content: '', truncated: false, error: blockReason };
   }
 
   try {
@@ -251,6 +255,15 @@ export async function fetchPageContent(
       maxContentLength: maxBytes,
       maxBodyLength: maxBytes,
       validateStatus: (status: number) => status >= 200 && status < 300,
+      // A redirect can point somewhere the original URL could not, so every hop
+      // is re-checked. Throwing here aborts the request chain.
+      beforeRedirect: (options: Record<string, any>) => {
+        const nextProtocol = String(options.protocol ?? '');
+        const nextHost = String(options.hostname ?? options.host ?? '');
+        if ((nextProtocol !== 'http:' && nextProtocol !== 'https:') || isBlockedHost(nextHost)) {
+          throw new Error('Refused to follow a redirect to a private, loopback or non-HTTP(S) address');
+        }
+      },
       headers: {
         'User-Agent': BROWSER_USER_AGENT,
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',

--- a/nodes/DuckDuckGo/urlGuard.ts
+++ b/nodes/DuckDuckGo/urlGuard.ts
@@ -1,0 +1,111 @@
+/**
+ * Outbound URL safety for the page-fetching features.
+ *
+ * `fetchPageContent` retrieves a caller-supplied URL, and the node is exposed to
+ * AI agents (`usableAsTool`). An agent can be steered by injected text — including
+ * text arriving inside the very search results this node returns — so the URL it
+ * asks for must be treated as untrusted input rather than an operator decision.
+ *
+ * Without this guard the n8n host can be made to fetch addresses only it can
+ * reach and hand the body back to the model, for example:
+ *   http://127.0.0.1:5678/rest/...            (n8n's own API)
+ *   http://169.254.169.254/latest/meta-data/  (cloud instance credentials)
+ *   http://10.0.0.5/, http://192.168.1.1/     (internal services)
+ *
+ * The checks are literal-address based and therefore cannot be defeated by the
+ * URL itself. They do NOT resolve DNS, so a hostname that resolves to a private
+ * address (DNS rebinding) is out of scope — see PROJECT_PLAN.md.
+ */
+
+/** Hosts that always denote the local machine. */
+const LOOPBACK_LITERALS = new Set(['localhost', '127.0.0.1', '::1', '0:0:0:0:0:0:0:1', '0.0.0.0', '::']);
+
+/** Decimal dotted-quad, captured as four octets. */
+const IPV4_PATTERN = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+/**
+ * True when an IPv4 address is not routable on the public internet.
+ * Covers loopback, link-local (cloud metadata), the RFC 1918 ranges, the
+ * carrier-grade NAT range, and "this network".
+ */
+function isPrivateIpv4(host: string): boolean {
+  const match = IPV4_PATTERN.exec(host);
+  if (!match) return false;
+
+  const octets = match.slice(1).map(Number);
+  if (octets.some((o) => Number.isNaN(o) || o > 255)) return false;
+  const [a, b] = octets;
+
+  if (a === 0) return true;                        // 0.0.0.0/8   this network
+  if (a === 10) return true;                       // 10.0.0.0/8  private
+  if (a === 127) return true;                      // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true;         // 169.254/16  link-local / metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12  private
+  if (a === 192 && b === 168) return true;         // 192.168/16  private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  return false;
+}
+
+/**
+ * True when an IPv6 literal is loopback, link-local, or unique-local.
+ * The host arrives without its surrounding brackets.
+ */
+function isPrivateIpv6(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === '::1' || h === '::' || h === '0:0:0:0:0:0:0:1') return true;
+  if (h.startsWith('fe80:')) return true;                       // link-local
+  if (/^f[cd][0-9a-f]{2}:/.test(h)) return true;                // fc00::/7 unique-local
+  // IPv4-mapped (e.g. ::ffff:127.0.0.1) must be judged on the embedded address.
+  const mapped = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(h);
+  if (mapped) return isPrivateIpv4(mapped[1]);
+  return false;
+}
+
+/**
+ * True when a hostname must not be fetched: a local name or a
+ * non-publicly-routable literal address.
+ */
+export function isBlockedHost(hostname: string): boolean {
+  // URL.hostname keeps IPv6 in brackets; compare the bare address.
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (host.length === 0) return true;
+  if (LOOPBACK_LITERALS.has(host)) return true;
+  // RFC 6761 reserves the whole .localhost TLD for the local machine.
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (isPrivateIpv4(host)) return true;
+  if (host.includes(':') && isPrivateIpv6(host)) return true;
+  return false;
+}
+
+/**
+ * Validate a URL that is about to be fetched on the caller's behalf.
+ *
+ * @returns The reason it must not be fetched, or null when it is acceptable.
+ */
+export function getUrlBlockReason(rawUrl: unknown): string | null {
+  if (typeof rawUrl !== 'string' || rawUrl.trim().length === 0) {
+    return 'No URL to fetch';
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return 'Invalid URL';
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return `Refused to fetch a non-HTTP(S) URL (${parsed.protocol.replace(':', '')})`;
+  }
+
+  if (isBlockedHost(parsed.hostname)) {
+    return 'Refused to fetch a private, loopback or link-local address';
+  }
+
+  return null;
+}
+
+/** Convenience wrapper for call sites that only need a yes/no answer. */
+export function isFetchableUrl(rawUrl: unknown): boolean {
+  return getUrlBlockReason(rawUrl) === null;
+}


### PR DESCRIPTION
## Problem

`fetchPageContent` retrieved **any** caller-supplied URL with no scheme or host validation.

The node is exposed to AI agents (`usableAsTool: true`), and an agent can be steered by injected text — including text arriving inside the very search results this node returns. That makes the URL **untrusted input**, not an operator decision.

Without a guard the n8n host could be made to read addresses only it can reach, and hand the body back to the model:

| Target | Why it matters |
|---|---|
| `http://127.0.0.1:5678/rest/...` | n8n's own API |
| `http://169.254.169.254/latest/meta-data/` | cloud instance credentials |
| `http://10.x / 192.168.x` | internal services |

## Changes

- **New `urlGuard.ts`** — a pure, unit-tested check rejecting non-`http(s)` schemes and loopback, `.localhost` (RFC 6761), `0.0.0.0`, `127.0.0.0/8`, `169.254.0.0/16`, RFC 1918, CGNAT `100.64/10`, and IPv6 `::1`, `fe80::/10`, `fc00::/7` plus IPv4-mapped forms.
- **Enforced before any request is made** in `fetchPageContent`.
- **Every redirect hop is re-checked** via axios's `beforeRedirect` hook — a redirect can reach where the original URL could not.

Blocked URLs return the module's normal `{ content: '', error }` shape instead of throwing, so per-result error handling in the batch path is unchanged.

## Known residual risk (recorded, not implied fixed)

**DNS rebinding is not covered** — a public hostname that *resolves* to a private address still passes, because the checks are literal-address based and do not resolve DNS. Closing it needs a custom `lookup` on the HTTP agents, which is larger scope with its own failure modes.

## Verification

`tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **313 tests / 14 suites** pass (40 new, none broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)