### PR TITLE
fix: try every known VQD token shape instead of a single pattern

### DIFF
--- a/nodes/DuckDuckGo/__tests__/vqdExtraction.test.ts
+++ b/nodes/DuckDuckGo/__tests__/vqdExtraction.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for vqdExtraction.ts.
+ *
+ * DuckDuckGo has served the VQD token in several shapes over time. Matching only
+ * one of them makes image search fail the moment the surrounding markup changes,
+ * even though the token is still on the page — these tests pin every known shape.
+ */
+
+import { extractVqd } from '../vqdExtraction';
+
+const TOKEN = '4-123456789012345678901234567890';
+
+describe('extractVqd', () => {
+  it.each([
+    ['a bare query parameter', `<a href="/i.js?q=cats&vqd=${TOKEN}">`],
+    ['a query parameter followed by another', `/i.js?vqd=${TOKEN}&o=json`],
+    ['a double-quoted value', `<input name="vqd" value="vqd=${TOKEN}">`],
+    ['a single-quoted assignment', `var v = 'vqd=${TOKEN}';`],
+    ['a JSON property', `<script>window.DDG={"vqd":"${TOKEN}","x":1}</script>`],
+    ['a JSON property with spacing', `{"vqd" : "${TOKEN}"}`],
+  ])('extracts the token from %s', (_label, body) => {
+    expect(extractVqd(body)).toBe(TOKEN);
+  });
+
+  it('extracts a short token of the historical form', () => {
+    expect(extractVqd('vqd=3-987654321')).toBe('3-987654321');
+  });
+
+  it('prefers the JSON form when a page contains both shapes', () => {
+    // A page that carries an older inline link plus the current JSON payload must
+    // still yield a usable token; either match is the same token in practice.
+    const body = `<a href="/x?vqd=${TOKEN}">link</a><script>{"vqd":"${TOKEN}"}</script>`;
+    expect(extractVqd(body)).toBe(TOKEN);
+  });
+
+  it.each([
+    ['a page with no token', '<html><body>no token here</body></html>'],
+    ['an empty string', ''],
+    ['undefined', undefined],
+    ['null', null],
+    ['a parsed object', { vqd: TOKEN }],
+  ])('returns null for %s', (_label, body) => {
+    expect(extractVqd(body)).toBeNull();
+  });
+
+  it('does not match a token-like word that is not a vqd assignment', () => {
+    expect(extractVqd('novqdhere 4-1234')).toBeNull();
+  });
+});

--- a/nodes/DuckDuckGo/directSearch.ts
+++ b/nodes/DuckDuckGo/directSearch.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { BROWSER_USER_AGENT } from './constants';
 import { assertNotChallenged } from './challengeDetection';
+import { extractVqd } from './vqdExtraction';
 import { DuckDuckGoError } from './errors';
 
 /**
@@ -251,8 +252,10 @@ export async function directImageSearch(query: string, options: {
       // instead of surfacing as a misleading "token could not be extracted".
       assertNotChallenged(response.data, response.status, 'image search');
 
-      const vqdMatch = response.data.match(/vqd=([\d-]+)/);
-      const extracted = vqdMatch ? vqdMatch[1] : null;
+      // DuckDuckGo has served this token as a bare parameter, a quoted value and
+      // a JSON property; extractVqd tries each known shape rather than betting
+      // on one, so a markup change does not silently break image search.
+      const extracted = extractVqd(response.data);
 
       if (!extracted) {
         throw new Error(

--- a/nodes/DuckDuckGo/vqdExtraction.ts
+++ b/nodes/DuckDuckGo/vqdExtraction.ts
@@ -1,0 +1,47 @@
+/**
+ * Extraction of DuckDuckGo's VQD token from a search page.
+ *
+ * The VQD is a short-lived, query-bound token that image, news and video
+ * requests must carry. DuckDuckGo does not publish it in a stable place: over
+ * time the same token has appeared as a bare query parameter, as a quoted
+ * attribute, and as a JSON property in an inline script. A single pattern is
+ * therefore a single point of failure — when DuckDuckGo changes the surrounding
+ * markup, extraction stops working even though the token is still present.
+ *
+ * Each known shape is tried in turn. All patterns capture the same token, so the
+ * first match wins and order only affects which shape is preferred.
+ */
+
+/**
+ * Known serialisations of the token, most specific first.
+ *
+ * The quoted and JSON forms are matched before the bare form so that a longer,
+ * correctly delimited match is preferred over a prefix of it.
+ */
+const VQD_PATTERNS: readonly RegExp[] = [
+  /"vqd"\s*:\s*"([\d-]+)"/,   // JSON property in an inline script
+  /vqd=["']([\d-]+)["']/,      // quoted attribute or assignment
+  /vqd=([\d-]+)&/,             // query parameter followed by another parameter
+  /vqd=([\d-]+)/,              // bare query parameter (historical form)
+];
+
+/**
+ * Return the VQD token found in a DuckDuckGo page, or null when none is present.
+ *
+ * Pure and side-effect free. Non-string input yields null so callers can pass a
+ * response body straight through without narrowing it first.
+ */
+export function extractVqd(body: unknown): string | null {
+  if (typeof body !== 'string' || body.length === 0) {
+    return null;
+  }
+
+  for (const pattern of VQD_PATTERNS) {
+    const match = pattern.exec(body);
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Problem

Image search extracted DuckDuckGo's VQD token with exactly one pattern:

```js
const vqdMatch = response.data.match(/vqd=([\d-]+)/);
```

That **cannot match the JSON form** `"vqd":"4-…"` which DuckDuckGo has been moving toward. A markup change would break image search even though the token was still on the page — a single point of failure.

## Change

New pure module `vqdExtraction.ts` tries each known serialisation in turn:

| Shape | Example |
|---|---|
| JSON property | `{"vqd":"4-123…"}` |
| Quoted value | `vqd="4-123…"` |
| Parameter + another | `vqd=4-123…&o=json` |
| Bare parameter (historical) | `vqd=4-123…` |

Wired into `directImageSearch` — verified by grep to be the only extraction site in the codebase.

## Verification

`tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **327 tests / 15 suites** pass (14 new, none broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)