### PR TITLE
chore(release): 32.10.0 — surface bot-detection challenges, SSRF guard, resilient VQD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [32.10.0] - 2026-09-06
+
+### Fixed
+
+- **Bot-detection challenges are no longer reported as "no results".** DuckDuckGo answers a client it considers automated with a human-verification page served as **HTTP 202**. Because 2xx is a success status, that page was parsed, no result blocks were found, and an **empty array was returned with no error**. `directSearch.ts` also encoded the assumption that "HTTP 202 = genuine no-results page", which is what silently swallowed it — DuckDuckGo uses 202 for both, so the response body is now inspected before the status is trusted. This is the root cause behind the long-standing "web search returns nothing" and "empty results after 2 or 3 executions" reports. The node now throws a named, non-retryable `BOT_CHALLENGE` error explaining that the instance's IP is temporarily blocked. Detection runs only where parsing already produced zero results, so text inside a real result can never trigger it.
+- **The News/Video fallback no longer masks a challenge.** It reports `challenged: true` instead of `success: true, noResults: true`, so an IP-level block is no longer indistinguishable from an empty result set.
+- **VQD extraction no longer depends on a single pattern.** Image search matched only `vqd=<digits>` and could not match the JSON form `"vqd":"…"` DuckDuckGo has been moving toward. Every known shape is now tried.
+
+### Security
+
+- **Page fetching refuses addresses that are not publicly routable.** `fetchPageContent` previously retrieved any caller-supplied URL with no scheme or host validation. Because the node is exposed to AI agents (`usableAsTool`), and an agent can be steered by text arriving inside the search results the node itself returns, that URL is untrusted input. It could be used to make the n8n host read its own API (`127.0.0.1:5678`), cloud instance metadata (`169.254.169.254`) or internal services, and return the contents to the model. Non-`http(s)` schemes and loopback, `.localhost`, `0.0.0.0`, `127.0.0.0/8`, `169.254.0.0/16`, RFC 1918, CGNAT and IPv6 loopback/link-local/unique-local addresses are now refused, and **every redirect hop is re-checked**. Known residual risk: DNS rebinding is not covered, because the checks are literal-address based and do not resolve DNS.
+
+### Documentation
+
+- README documents the bot-detection challenge, what triggers it, how to reduce it, and the refused-address behaviour.
+
+---
+
 ## [32.9.2] - 2026-06-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -457,6 +457,23 @@ This allows downstream nodes and AI Agents to detect and handle fallback results
 
 The node surfaces specific, actionable error messages rather than generic failures.
 
+### Bot-detection challenge (rate limiting)
+
+DuckDuckGo answers a client it considers automated with a human-verification page instead of results. That page is served with **HTTP 202**, which ordinary HTTP clients treat as success — so earlier versions parsed it, found no result blocks, and returned an **empty array with no error at all**.
+
+The node now detects that page and throws:
+
+> `DuckDuckGo served a bot-detection challenge instead of results. This blocks the IP address your n8n instance sends requests from, typically for tens of minutes. Wait before retrying, and reduce how frequently this node runs — shared or cloud IP addresses are affected sooner.`
+
+**What triggers it:** roughly fifteen or more requests from the same IP within a few minutes. The block is tied to the **IP address** — not to your account, query or region — lasts tens of minutes, and is not cleared by retrying or by changing User-Agent. The node therefore marks this error **non-retryable**: an immediate retry only prolongs the block.
+
+**If you hit it regularly:**
+
+- Space executions out, and put a **Wait** node between iterations of a loop
+- Reduce **Max Results** and avoid re-running the same workflow in tight cycles
+- On n8n Cloud or shared hosting you share an outbound IP with other tenants, so the threshold is reached sooner
+- Enable **Cache Settings** so repeated identical queries do not reach DuckDuckGo again
+
 ### Image Search: VQD token missing
 
 If DuckDuckGo's image search page does not return a valid VQD token (a session token required to query image results), the node throws:
@@ -481,9 +498,22 @@ If `directWebSearch` receives an HTTP 200 response with a large body but cannot 
 
 This is distinct from a genuine no-results response, which returns an empty array without an error.
 
+### Extract Page Content: refused address
+
+**Extract Page Content** and **Fetch Page Content** retrieve a URL supplied by the caller — and when the node runs as an AI Agent tool, the agent chooses that URL. The node therefore refuses any address that is not publicly routable:
+
+> `Refused to fetch a private, loopback or link-local address`
+> `Refused to fetch a non-HTTP(S) URL (file)`
+
+Refused targets include `localhost` and `127.0.0.0/8`, cloud instance metadata (`169.254.169.254`), the private ranges (`10/8`, `172.16/12`, `192.168/16`), IPv6 loopback / link-local / unique-local addresses, and every non-`http(s)` scheme. **Redirects are re-checked at each hop**, so a public URL cannot redirect into a private one.
+
+This stops a prompt-injected agent from making your n8n host read internal services — including n8n's own API — and hand their contents back to the model. Fetching internal addresses is deliberately unsupported.
+
 ### Empty results
 
 An empty result array (`[]`) is a valid response when DuckDuckGo genuinely finds no results for the query. This is not an error condition.
+
+Since v32.10.0 an empty array means only that. A bot-detection challenge is reported as the error above instead of being reported as "no results".
 
 ---
 
@@ -616,6 +646,13 @@ The following field names were incorrect in previous documentation. Use the name
 - Check region/language settings — some queries return fewer results in non-default locales
 - Verify safe search settings are not filtering valid results
 - DuckDuckGo may temporarily return no results for some queries; retry after a short delay
+- If every query comes back empty after a few successful runs, you are most likely rate-limited — see [bot-detection challenge](#search-returns-a-bot-detection-challenge-error)
+
+### Search returns a bot-detection challenge error
+
+Your n8n instance's outbound IP address has been temporarily blocked by DuckDuckGo — see [Bot-detection challenge](#bot-detection-challenge-rate-limiting) for what triggers it and how to reduce it. Wait before retrying; the block lasts tens of minutes and immediate retries prolong it. This is not a fault in the node or in your query.
+
+Before v32.10.0 this condition returned an empty result list with no error, which is the cause behind most historical "web search returns nothing" reports.
 
 ### Image search fails with VQD error
 
@@ -689,6 +726,7 @@ To get **more text**, enable **Fetch Page Content** (available on **Web Search**
 - **No credentials registered**: The n8n credential registry for this package is empty. n8n will not prompt for any DuckDuckGo credentials.
 - **Direct requests only (by default)**: Search requests go directly to DuckDuckGo (`duckduckgo.com`, `html.duckduckgo.com`, `i.js`). No third-party search API, proxy, or intermediary is involved. The one exception is the opt-in Fetch Page Content feature below.
 - **Optional page-content fetch (off by default)**: If you enable **Fetch Page Content** (Web or News Search), the node additionally requests each fetched result's page from its own third-party server to extract text. This is the only path that contacts non-DuckDuckGo hosts, and it is disabled unless you turn it on. See [Page Content Extraction](#-page-content-extraction).
+- **Outbound fetches are restricted**: the page-fetching features refuse non-`http(s)` schemes and any private, loopback or link-local address (including cloud instance metadata), and re-check every redirect hop. This holds even when an AI Agent chooses the URL.
 - **No disk storage**: The node does not write queries or results to disk. Optional in-memory caching may temporarily keep results for the configured cache TTL (default 5 minutes) within the running n8n process.
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,62 @@
+# v32.10.0 — Bot-detection challenges surfaced, SSRF guard, resilient VQD
+
+**Release Date:** 2026-09-06
+
+The most significant correctness and security release since the page-content features. No breaking
+API changes; one deliberate behaviour change described below.
+
+---
+
+## Why this matters
+
+If your Web Search sometimes returned **nothing at all** — especially after a few successful runs —
+this release explains and fixes it. DuckDuckGo serves a human-verification page to clients it
+considers automated, using **HTTP 202**. Because 2xx means success, the node parsed that page, found
+no results, and returned an empty list **with no error**. It looked like "DuckDuckGo has no results
+for this query" when it actually meant "your IP is temporarily blocked".
+
+## Highlights
+
+- **Bot-detection challenges are now surfaced**, with a named, non-retryable error that says the
+  instance's IP is blocked and roughly how long for. Retrying immediately prolongs the block, so the
+  node deliberately does not mark it retryable.
+- **Security: page fetching refuses private addresses.** Extract Page Content / Fetch Page Content
+  no longer retrieve loopback, link-local (cloud metadata) or RFC 1918 addresses, or non-HTTP(S)
+  schemes — and every redirect hop is re-checked. This matters because the node runs as an AI Agent
+  tool, where the agent chooses the URL and can be steered by injected text.
+- **Image search is more robust**: the VQD token is matched in every shape DuckDuckGo has used,
+  not just one.
+- **The News/Video fallback no longer hides a block** behind "no results".
+
+## Behaviour change
+
+Where a rate-limited search previously returned `[]` with no error, it now **throws**. If a workflow
+relied on the empty array, set **On Error → Continue** on the node, or check for the error item.
+A genuine empty result set still returns `[]` as before.
+
+## Compatibility
+
+- No breaking API or output-shape changes. New optional `challenged` flag on fallback responses.
+
+---
+
+## Validation
+
+- `tsc`, ESLint, `npm run build:prod`, `verify-build`, and the full suite — **327 tests across 15
+  suites** — all pass. Three new pure modules (`challengeDetection`, `urlGuard`, `vqdExtraction`)
+  are unit-tested directly, including a regression test that a genuine HTTP 202 no-results page
+  still returns an empty list.
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.10.0
+```
+
+---
+
 # v32.9.2 — Maintenance (readability 0.6, ESLint flat config, deps)
 
 **Release Date:** 2026-06-25

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.9.2",
+  "version": "32.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.9.2",
+      "version": "32.10.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.9.2",
+  "version": "32.10.0",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Ships the P0 correctness and security work already merged in #39, #40 and #41, plus the documentation users need to interpret the new error.

## What ships

| Area | Change |
|---|---|
| **Fixed** | Bot-detection challenges are surfaced instead of being returned as an empty result set — the root cause behind the long-standing *"web search returns nothing"* reports |
| **Fixed** | News/Video fallback reports `challenged: true` instead of masking a block as "no results" |
| **Fixed** | VQD extraction tries every known token shape, not only `vqd=<digits>` |
| **Security** | Page fetching refuses private, loopback, link-local and non-HTTP(S) addresses, re-checked at every redirect hop |
| **Docs** | README explains what triggers the challenge, how to reduce it, and the refused-address behaviour |

## Deliberate behaviour change

A rate-limited search now **throws** where it previously returned `[]` with no error. A genuine empty result set still returns `[]`. Workflows that relied on the silent empty array should set **On Error → Continue**. This is called out in the release notes and is why the version is a **minor**, not a patch.

## Verification

`tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **327 tests / 15 suites** pass · packed tarball confirmed to contain the three new modules and no internal files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)