### PR TITLE
feat: add Search Suggestions (autocomplete) operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [32.11.0] - 2026-09-06
+
+### Added
+
+- **New operation: Search Suggestions (autocomplete).** Returns DuckDuckGo's query suggestions for a partial search term via its public suggestion endpoint — no VQD token, no key, and a very small payload. Options: `maxResults` (default 10), `region`, and `splitIntoItems` to emit one n8n item per suggestion instead of a single item holding the list. Useful for query expansion, keyword research, and offering an AI Agent alternative phrasings before it commits to a search.
+
+  This endpoint was **the surface least affected by rate limiting** during endpoint testing, so it often still answers when Web Search is temporarily blocked — a deliberate companion to the challenge detection added in 32.10.0. Both response shapes DuckDuckGo has returned (the `type=list` pair form and the `{ phrase }` object form) are handled, and an unfamiliar shape degrades to an empty list rather than throwing.
+
+---
+
 ## [32.10.0] - 2026-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An n8n community node for DuckDuckGo search. Search the web, find images, discov
 - **Optional page content extraction**: Fetch and extract the main text of result pages (Web and News, opt-in), with optional page metadata
 - **Extract Page Content operation**: Give any URL → clean main text + metadata (a "read any page" tool for AI Agents)
 - **Instant Answer operation**: Direct answers, abstracts, and definitions from DuckDuckGo's free Instant Answer API
+- **Search Suggestions operation**: Query autocomplete from DuckDuckGo's suggestion endpoint — the surface least affected by rate limiting
 
 ---
 
@@ -329,6 +330,61 @@ Returns DuckDuckGo's **Instant Answer** for a query — a direct answer, a Wikip
 
 ---
 
+### Search Suggestions
+
+Returns DuckDuckGo's autocomplete suggestions for a partial query — what the search box would offer as you type. Useful for query expansion, keyword research, and giving an AI Agent alternative phrasings before it commits to a search.
+
+This uses DuckDuckGo's suggestion endpoint, which needs no VQD token and returns a very small payload. In endpoint testing it was **the surface least affected by rate limiting**, so it often still answers when Web Search is temporarily blocked.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `autocompleteQuery` | string | required | The partial search term |
+| `maxResults` | number | 10 | Maximum suggestions (1–50) |
+| `region` | options | wt-wt | Locale code (e.g. `de-de`) |
+| `splitIntoItems` | boolean | false | Return one n8n item per suggestion instead of one item holding the list |
+
+**Example:**
+
+```json
+{
+  "operation": "autocomplete",
+  "autocompleteQuery": "how to build",
+  "autocompleteOptions": {
+    "maxResults": 5,
+    "region": "us-en"
+  }
+}
+```
+
+**Sample output (default):**
+
+```json
+{
+  "query": "how to build",
+  "suggestions": [
+    "how to build a pc",
+    "how to build credit fast",
+    "how to build a website",
+    "how to build an ai agent"
+  ],
+  "count": 4,
+  "sourceType": "autocomplete"
+}
+```
+
+**Sample output (`splitIntoItems: true`)** — one item per suggestion, ready to fan out into a loop:
+
+```json
+[
+  { "query": "how to build", "suggestion": "how to build a pc", "position": 1, "sourceType": "autocomplete" },
+  { "query": "how to build", "suggestion": "how to build a website", "position": 2, "sourceType": "autocomplete" }
+]
+```
+
+---
+
 ## ⚙️ Configuration Reference
 
 ### Common Parameters (all operations)
@@ -473,6 +529,7 @@ The node now detects that page and throws:
 - Reduce **Max Results** and avoid re-running the same workflow in tight cycles
 - On n8n Cloud or shared hosting you share an outbound IP with other tenants, so the threshold is reached sooner
 - Enable **Cache Settings** so repeated identical queries do not reach DuckDuckGo again
+- The **Search Suggestions** operation uses a different, much lighter endpoint and is the least affected by this limit
 
 ### Image Search: VQD token missing
 
@@ -739,6 +796,7 @@ To get **more text**, enable **Fetch Page Content** (available on **Web Search**
 | Image Search | `directImageSearch` (duckduckgo.com + i.js) | None |
 | News Search | `duck-duck-scrape` `searchNews` | HTML-based fallback |
 | Video Search | `duck-duck-scrape` `searchVideos` | HTML-based fallback |
+| Search Suggestions | `getAutocomplete` (duckduckgo.com/ac/) | None |
 
 There is no user-configurable backend selector. Each operation type uses the most reliable path available. Every path — primary and fallback — talks only to DuckDuckGo; no third-party search API is used.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,48 @@
+# v32.11.0 — Search Suggestions (autocomplete)
+
+**Release Date:** 2026-09-06
+
+Adds a seventh operation. Free, no API key, no new dependencies — as always.
+
+---
+
+## Highlights
+
+- **New operation: Search Suggestions.** Give it a partial query and it returns DuckDuckGo's
+  autocomplete suggestions — what the search box would offer as you type.
+- **`splitIntoItems`** emits one n8n item per suggestion, so the results drop straight into a loop.
+- **Region aware** (`kl`), verified live against `us-en` and `de-de`.
+
+## Why this one is worth having
+
+It uses a different, much lighter DuckDuckGo endpoint than search: no VQD token, no cookies, a
+response of a few hundred bytes. During the endpoint testing behind 32.10.0 it was **the only
+surface never answered with a bot-detection challenge** — so when Web Search is temporarily
+rate-limited, this operation generally still works. It pairs naturally with the challenge detection
+shipped in 32.10.0.
+
+## Compatibility
+
+- Purely additive. No changes to existing operations or output shapes.
+
+---
+
+## Validation
+
+- `tsc`, ESLint, `build:prod`, `verify-build`, and **344 tests across 16 suites** pass.
+- Verified live against the real endpoint in English and German, including region handling and the
+  empty-query guard.
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.11.0
+```
+
+---
+
 # v32.10.0 — Bot-detection challenges surfaced, SSRF guard, resilient VQD
 
 **Release Date:** 2026-09-06

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -59,6 +59,7 @@ import { paginateWithVqd, DEFAULT_PAGINATION_CONFIG } from './vqdPagination';
 import { fallbackNewsSearch, fallbackVideoSearch } from './fallbackSearch';
 import { fetchPageContent, fetchPageContents } from './pageContent';
 import { getInstantAnswer } from './instantAnswer';
+import { getAutocomplete } from './autocomplete';
 
 // Sleep for a fixed amount of time
 function sleep(ms: number): Promise<void> {
@@ -253,6 +254,12 @@ export class DuckDuckGo implements INodeType {
             value: DuckDuckGoOperation.InstantAnswer,
             description: 'Get a direct answer, abstract, or definition from DuckDuckGo',
             action: 'Get an instant answer',
+          },
+          {
+            name: 'Search Suggestions',
+            value: DuckDuckGoOperation.Autocomplete,
+            description: 'Get query suggestions (autocomplete) for a partial search term',
+            action: 'Get search suggestions',
           }
         ],
       },
@@ -340,6 +347,68 @@ export class DuckDuckGo implements INodeType {
             ],
           },
         },
+      },
+
+      // ----------------------------------------
+      // Search Suggestions Operation Parameters
+      // ----------------------------------------
+      {
+        displayName: 'Partial Query',
+        name: 'autocompleteQuery',
+        type: 'string',
+        required: true,
+        default: '',
+        description: 'The partial search term to get suggestions for',
+        placeholder: 'e.g. how to build',
+        displayOptions: {
+          show: {
+            operation: [
+              DuckDuckGoOperation.Autocomplete,
+            ],
+          },
+        },
+      },
+      {
+        displayName: 'Options',
+        name: 'autocompleteOptions',
+        type: 'collection',
+        placeholder: 'Add Option',
+        default: {},
+        displayOptions: {
+          show: {
+            operation: [
+              DuckDuckGoOperation.Autocomplete,
+            ],
+          },
+        },
+        options: [
+          {
+            displayName: 'Maximum Suggestions',
+            name: 'maxResults',
+            type: 'number',
+            default: 10,
+            typeOptions: {
+              minValue: 1,
+              maxValue: 50,
+            },
+            description: 'Maximum number of suggestions to return',
+          },
+          {
+            displayName: 'Region',
+            name: 'region',
+            type: 'options',
+            options: REGIONS,
+            default: DEFAULT_PARAMETERS.REGION,
+            description: 'Region/language for the suggestions',
+          },
+          {
+            displayName: 'Split Into Items',
+            name: 'splitIntoItems',
+            type: 'boolean',
+            default: false,
+            description: 'Whether to return one n8n item per suggestion instead of a single item holding the list',
+          },
+        ],
       },
 
       // ----------------------------------------
@@ -2365,6 +2434,54 @@ export class DuckDuckGo implements INodeType {
           }
 
           results = [{ json, pairedItem: { item: itemIndex } }];
+        }
+        else if (operation === DuckDuckGoOperation.Autocomplete) {
+          const partialQuery = this.getNodeParameter('autocompleteQuery', itemIndex) as string;
+          if (!partialQuery || partialQuery.trim() === '') {
+            throw new NodeOperationError(
+              this.getNode(),
+              'Partial Query is required for the Search Suggestions operation',
+              { itemIndex }
+            );
+          }
+
+          const acOptions = this.getNodeParameter('autocompleteOptions', itemIndex, {}) as {
+            maxResults?: number;
+            region?: string;
+            splitIntoItems?: boolean;
+          };
+
+          const ac = await getAutocomplete(partialQuery.trim(), {
+            maxResults: acOptions.maxResults ?? 10,
+            region: acOptions.region ?? DEFAULT_PARAMETERS.REGION,
+            timeout: 8000,
+          });
+
+          // One item per suggestion is the shape most workflows want when the
+          // suggestions are fanned out; the default keeps them together so a
+          // single execution maps to a single item.
+          if (acOptions.splitIntoItems && ac.suggestions.length > 0) {
+            results = ac.suggestions.map((suggestion, position) => ({
+              json: {
+                query: partialQuery.trim(),
+                suggestion,
+                position: position + 1,
+                sourceType: 'autocomplete',
+              } as IDataObject,
+              pairedItem: { item: itemIndex },
+            }));
+          } else {
+            const json: IDataObject = {
+              query: partialQuery.trim(),
+              suggestions: ac.suggestions,
+              count: ac.suggestions.length,
+              sourceType: 'autocomplete',
+            };
+            if (ac.error) {
+              json.error = ac.error;
+            }
+            results = [{ json, pairedItem: { item: itemIndex } }];
+          }
         }
         else {
           throw new NodeOperationError(

--- a/nodes/DuckDuckGo/__tests__/autocomplete.test.ts
+++ b/nodes/DuckDuckGo/__tests__/autocomplete.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for autocomplete.ts.
+ *
+ * DuckDuckGo has returned two different shapes from /ac/ — the `type=list`
+ * pair form and an array of `{ phrase }` objects — and neither is contractual,
+ * so both are pinned here along with graceful handling of anything else.
+ */
+
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { getAutocomplete, parseSuggestions } from '../autocomplete';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('parseSuggestions', () => {
+  it('reads the type=list pair form', () => {
+    expect(parseSuggestions(['n8n', ['n8n docs', 'n8n cloud', 'n8n nodes']]))
+      .toEqual(['n8n docs', 'n8n cloud', 'n8n nodes']);
+  });
+
+  it('reads the phrase-object form', () => {
+    expect(parseSuggestions([{ phrase: 'n8n docs' }, { phrase: 'n8n cloud' }]))
+      .toEqual(['n8n docs', 'n8n cloud']);
+  });
+
+  it('drops entries that are not usable strings', () => {
+    expect(parseSuggestions(['q', ['good', '', '   ', 42, null, 'also good']]))
+      .toEqual(['good', 'also good']);
+    expect(parseSuggestions([{ phrase: 'kept' }, { nope: 1 }, null, { phrase: '  ' }]))
+      .toEqual(['kept']);
+  });
+
+  it.each([
+    ['a non-array', { suggestions: [] }],
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty array', []],
+  ])('returns an empty list for %s', (_label, data) => {
+    expect(parseSuggestions(data)).toEqual([]);
+  });
+});
+
+describe('getAutocomplete', () => {
+  it('returns suggestions for a partial query', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ['how to', ['how to build', 'how to code']] });
+
+    const result = await getAutocomplete('how to');
+
+    expect(result.error).toBeUndefined();
+    expect(result.suggestions).toEqual(['how to build', 'how to code']);
+  });
+
+  it('requests the list shape and no region by default', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ['x', []] });
+
+    await getAutocomplete('x');
+
+    const url = mockedAxios.get.mock.calls[0][0] as string;
+    expect(url).toContain('duckduckgo.com/ac/');
+    expect(url).toContain('type=list');
+    expect(url).not.toContain('kl=');
+  });
+
+  it('passes the region through as kl', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ['x', []] });
+
+    await getAutocomplete('x', { region: 'de-de' });
+
+    expect(mockedAxios.get.mock.calls[0][0] as string).toContain('kl=de-de');
+  });
+
+  it('caps the list at maxResults', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ['a', ['1', '2', '3', '4', '5']] });
+
+    const result = await getAutocomplete('a', { maxResults: 3 });
+
+    expect(result.suggestions).toEqual(['1', '2', '3']);
+  });
+
+  it('treats maxResults of 0 as no limit', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: ['a', ['1', '2', '3']] });
+
+    const result = await getAutocomplete('a', { maxResults: 0 });
+
+    expect(result.suggestions).toHaveLength(3);
+  });
+
+  it.each([
+    ['an empty query', ''],
+    ['whitespace only', '   '],
+  ])('rejects %s without making a request', async (_label, query) => {
+    const result = await getAutocomplete(query);
+
+    expect(result.error).toBe('No query provided');
+    expect(result.suggestions).toEqual([]);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('reports a timeout instead of throwing', async () => {
+    mockedAxios.get.mockRejectedValueOnce({ code: 'ECONNABORTED' });
+
+    const result = await getAutocomplete('x', { timeout: 1234 });
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.error).toBe('Timed out after 1234ms');
+  });
+
+  it('reports an HTTP error instead of throwing', async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 503 } });
+
+    const result = await getAutocomplete('x');
+
+    expect(result.error).toBe('HTTP 503');
+  });
+
+  it('degrades to an empty list when the payload shape is unfamiliar', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { unexpected: true } });
+
+    const result = await getAutocomplete('x');
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/nodes/DuckDuckGo/autocomplete.ts
+++ b/nodes/DuckDuckGo/autocomplete.ts
@@ -1,0 +1,106 @@
+/**
+ * DuckDuckGo search-suggestion (autocomplete) client.
+ *
+ * Uses DuckDuckGo's public suggestion endpoint (https://duckduckgo.com/ac/),
+ * which needs no VQD token, no cookies and no API key, and returns a tiny
+ * payload. During endpoint probing it was the only DuckDuckGo surface that was
+ * never answered with a bot-detection challenge, which makes it a useful
+ * companion when search itself is rate-limited.
+ *
+ * With `type=list` the response is `["<query>", ["suggestion", ...]]`; without
+ * it, an array of `{ phrase }` objects. Both shapes are accepted here because
+ * DuckDuckGo has returned each of them, and neither is contractual.
+ */
+
+import axios from 'axios';
+import { BROWSER_USER_AGENT } from './constants';
+
+export interface AutocompleteResult {
+  /** Suggested queries, in DuckDuckGo's own order. */
+  suggestions: string[];
+  /** Present only when the request failed. */
+  error?: string;
+}
+
+export interface AutocompleteOptions {
+  /** DuckDuckGo region code, e.g. `us-en`, `de-de`, `wt-wt`. */
+  region?: string;
+  /** Maximum suggestions to keep. 0 or negative means no limit. */
+  maxResults?: number;
+  /** Request timeout in milliseconds. */
+  timeout?: number;
+}
+
+const DEFAULT_TIMEOUT = 8000;
+
+/**
+ * Pull suggestion strings out of either response shape, ignoring anything that
+ * is not a usable string so a format change degrades rather than throws.
+ */
+export function parseSuggestions(data: unknown): string[] {
+  if (!Array.isArray(data)) return [];
+
+  // `type=list` shape: ["query", ["a", "b", ...]]
+  if (Array.isArray(data[1])) {
+    return (data[1] as unknown[]).filter((s): s is string => typeof s === 'string' && s.trim() !== '');
+  }
+
+  // Object shape: [{ phrase: "a" }, ...]
+  return (data as unknown[])
+    .map((item) => (item && typeof (item as any).phrase === 'string' ? (item as any).phrase : ''))
+    .filter((s) => s.trim() !== '');
+}
+
+/**
+ * Fetch search suggestions for a partial query. Never throws: failures are
+ * reported via the `error` field, matching the Instant Answer client.
+ */
+export async function getAutocomplete(
+  query: string,
+  options: AutocompleteOptions = {},
+): Promise<AutocompleteResult> {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+  const maxResults = options.maxResults ?? 0;
+
+  if (!query || typeof query !== 'string' || query.trim() === '') {
+    return { suggestions: [], error: 'No query provided' };
+  }
+
+  try {
+    const params = new URLSearchParams({
+      q: query.trim(),
+      type: 'list',
+    });
+    if (options.region && options.region.trim() !== '') {
+      params.set('kl', options.region.trim());
+    }
+
+    const response = await axios.get(`https://duckduckgo.com/ac/?${params.toString()}`, {
+      timeout,
+      responseType: 'json',
+      headers: {
+        'User-Agent': BROWSER_USER_AGENT,
+        'Accept': 'application/json',
+      },
+    });
+
+    let suggestions = parseSuggestions(response.data);
+    if (maxResults > 0 && suggestions.length > maxResults) {
+      suggestions = suggestions.slice(0, maxResults);
+    }
+
+    return { suggestions };
+  } catch (error: any) {
+    let message: string;
+    if (error?.code === 'ECONNABORTED') {
+      message = `Timed out after ${timeout}ms`;
+    } else if (error?.response?.status) {
+      message = `HTTP ${error.response.status}`;
+    } else if (error?.code) {
+      message = String(error.code);
+    } else {
+      message = error instanceof Error ? error.message : 'Unknown error';
+    }
+    return { suggestions: [], error: message };
+  }
+}

--- a/nodes/DuckDuckGo/types.ts
+++ b/nodes/DuckDuckGo/types.ts
@@ -25,6 +25,7 @@ export enum DuckDuckGoOperation {
   SearchVideos = 'searchVideos',
   ExtractContent = 'extractContent',
   InstantAnswer = 'instantAnswer',
+  Autocomplete = 'autocomplete',
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.10.0",
+  "version": "32.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.10.0",
+      "version": "32.11.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.10.0",
+  "version": "32.11.0",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Adds a seventh operation: DuckDuckGo's query suggestions for a partial search term.

## Why this one

It uses a different, much lighter endpoint than search — no VQD token, no cookies, a few hundred bytes. During the endpoint testing behind #42, `/ac/` was **the only DuckDuckGo surface never answered with a bot-detection challenge**, so it generally still works while Web Search is temporarily rate-limited. That makes it a deliberate companion to the challenge detection shipped in 32.10.0, not just another operation.

## What it does

| Option | Default | Effect |
|---|---|---|
| `maxResults` | 10 | Cap the suggestion list (1–50) |
| `region` | `wt-wt` | Passed through as `kl` |
| `splitIntoItems` | false | One n8n item per suggestion, ready to fan out into a loop |

## Robustness

DuckDuckGo has returned **two** shapes from this endpoint and neither is contractual, so both are handled — the `type=list` pair form and the `{ phrase }` object form. An unfamiliar shape degrades to an empty list rather than throwing, and errors surface in an `error` field, matching the Instant Answer client.

## Verification

`tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **344 tests / 16 suites** (17 new, none broken).

Also verified live against the real endpoint:
- `us-en` "how to build" → 8 suggestions
- `de-de` "wetter" → 5 German suggestions (region handling confirmed)
- empty query → guarded, no request made

🤖 Generated with [Claude Code](https://claude.com/claude-code)