### PR TITLE
feat: back off for a minute after a bot-detection challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [32.12.0] - 2026-09-07
+
+### Changed
+
+- **The node now backs off after a bot-detection challenge.** Once DuckDuckGo serves a challenge, further search requests are refused locally for about a minute instead of being sent, with an error stating how many seconds remain. Every request made during a block is wasted, adds load to a service that has just said stop, and prolongs the block for everyone sharing that outbound IP — which on n8n Cloud means other tenants. The window is deliberately far shorter than the block itself, so the node throttles rather than stops: roughly one probe per minute goes out, and normal operation resumes within a minute of the block lifting.
+
+  This completes the fallback-amplification fix started in 32.10.0. A challenge seen by Web Search now also holds back the News/Video fallback, which previously could not tell a challenge from any other failure because its primary path (`duck-duck-scrape`) fails opaquely.
+
+---
+
 ## [32.11.0] - 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -523,6 +523,8 @@ The node now detects that page and throws:
 
 **What triggers it:** roughly fifteen or more requests from the same IP within a few minutes. The block is tied to the **IP address** — not to your account, query or region — lasts tens of minutes, and is not cleared by retrying or by changing User-Agent. The node therefore marks this error **non-retryable**: an immediate retry only prolongs the block.
 
+**Automatic back-off.** Once a challenge is seen, the node refuses further DuckDuckGo requests locally for about a minute instead of sending them, and says how many seconds remain. Every request made during a block is wasted and prolongs it, so this protects the shared IP rather than your workflow's throughput — requests resume on their own.
+
 **If you hit it regularly:**
 
 - Space executions out, and put a **Wait** node between iterations of a loop

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,53 @@
+# v32.12.0 — Automatic back-off after a bot-detection challenge
+
+**Release Date:** 2026-09-07
+
+Completes the rate-limiting work started in 32.10.0. No new operations, no API changes.
+
+---
+
+## What changed
+
+Once DuckDuckGo serves a bot-detection challenge, the node now **refuses further search requests
+locally for about a minute** instead of sending them, and tells you how many seconds remain.
+
+## Why
+
+Every request sent during a block is wasted: the block follows your instance's outbound IP, lasts
+tens of minutes, and each extra request prolongs it — for everyone sharing that address, which on
+n8n Cloud means other tenants.
+
+The window is deliberately much shorter than the block. The node throttles rather than stops:
+roughly one probe per minute still goes out, so normal operation resumes within a minute of the
+block lifting instead of being sidelined for its full duration.
+
+This also closes the last gap from 32.10.0: a challenge seen by Web Search now holds back the
+News/Video fallback too. That path could not previously detect a challenge itself, because its
+primary (`duck-duck-scrape`) fails opaquely.
+
+## Compatibility
+
+- No API or output-shape changes. During a back-off you get the same `BOT_CHALLENGE` error type,
+  with a message that says the request was not sent and when it will resume.
+
+---
+
+## Validation
+
+- `tsc`, ESLint, `build:prod`, `verify-build`, and **354 tests across 17 suites** pass, including a
+  test that a challenge on one path stops the next request on another, and that requests resume once
+  the window has passed.
+
+---
+
+## Installation
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.12.0
+```
+
+---
+
 # v32.11.0 — Search Suggestions (autocomplete)
 
 **Release Date:** 2026-09-06

--- a/nodes/DuckDuckGo/__tests__/challengeCooldown.test.ts
+++ b/nodes/DuckDuckGo/__tests__/challengeCooldown.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for challengeCooldown.ts and its effect on the request paths.
+ *
+ * After DuckDuckGo serves a challenge, further requests are wasted: the block
+ * follows the IP, lasts tens of minutes, and every extra request prolongs it.
+ * The back-off makes the node fail fast locally instead of sending them.
+ */
+
+jest.mock('axios');
+
+import axios from 'axios';
+
+import {
+  CHALLENGE_COOLDOWN_MS,
+  getCooldownReason,
+  getRemainingCooldownMs,
+  noteChallenge,
+  resetChallengeCooldown,
+} from '../challengeCooldown';
+import { createChallengeError } from '../challengeDetection';
+import { DuckDuckGoErrorType } from '../errors';
+import { directWebSearch, directImageSearch } from '../directSearch';
+import { fallbackWebSearch } from '../fallbackSearch';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const CHALLENGE_HTML =
+  '<div id="anomaly-modal">Please complete the following challenge</div>';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetChallengeCooldown();
+});
+
+describe('challengeCooldown', () => {
+  it('reports no back-off when nothing has happened', () => {
+    expect(getRemainingCooldownMs()).toBe(0);
+    expect(getCooldownReason()).toBeNull();
+  });
+
+  it('starts a back-off window when a challenge is noted', () => {
+    const now = 1_000_000;
+    noteChallenge(now);
+
+    expect(getRemainingCooldownMs(now)).toBe(CHALLENGE_COOLDOWN_MS);
+    expect(getRemainingCooldownMs(now + 10_000)).toBe(CHALLENGE_COOLDOWN_MS - 10_000);
+  });
+
+  it('expires exactly at the end of the window', () => {
+    const now = 1_000_000;
+    noteChallenge(now);
+
+    expect(getRemainingCooldownMs(now + CHALLENGE_COOLDOWN_MS - 1)).toBe(1);
+    expect(getRemainingCooldownMs(now + CHALLENGE_COOLDOWN_MS)).toBe(0);
+    expect(getCooldownReason(now + CHALLENGE_COOLDOWN_MS)).toBeNull();
+  });
+
+  it('explains the wait in seconds, and says requests resume by themselves', () => {
+    const now = 1_000_000;
+    noteChallenge(now);
+
+    const reason = getCooldownReason(now + 30_000) as string;
+    expect(reason).toContain('30s');
+    expect(reason).toContain('was not sent');
+    expect(reason.toLowerCase()).toContain('ip address');
+  });
+
+  it('is started by creating a challenge error, wherever that happens', () => {
+    expect(getRemainingCooldownMs()).toBe(0);
+
+    createChallengeError('web search', 202);
+
+    expect(getRemainingCooldownMs()).toBeGreaterThan(0);
+  });
+});
+
+describe('request paths during the back-off', () => {
+  it('web search fails fast without sending a request', async () => {
+    noteChallenge();
+
+    await expect(directWebSearch('anything')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('image search fails fast without sending a request', async () => {
+    noteChallenge();
+
+    await expect(directImageSearch('cats')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('the fallback path reports it without sending a request', async () => {
+    noteChallenge();
+
+    const response = await fallbackWebSearch('anything');
+
+    expect(response.challenged).toBe(true);
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('was not sent');
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('a challenge on one path stops the next request on another', async () => {
+    // The block follows the IP, so a challenge seen by web search must also
+    // hold back the fallback path — this is what stopped the amplification.
+    mockedAxios.post.mockResolvedValueOnce({ status: 202, data: CHALLENGE_HTML });
+
+    await expect(directWebSearch('anything')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+
+    const response = await fallbackWebSearch('anything');
+    expect(response.challenged).toBe(true);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('requests resume once the window has passed', async () => {
+    noteChallenge(Date.now() - CHALLENGE_COOLDOWN_MS - 1);
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 200,
+      data: `<div class="result results_links"><h2 class="result__title">
+        <a class="result__a" href="https://example.com/a">Example</a></h2>
+        <a class="result__snippet" href="https://example.com/a">Snippet.</a></div>`,
+    });
+
+    const output = await directWebSearch('anything');
+
+    expect(output.results).toHaveLength(1);
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nodes/DuckDuckGo/__tests__/jest.setup.ts
+++ b/nodes/DuckDuckGo/__tests__/jest.setup.ts
@@ -1,2 +1,12 @@
-// This file allows us to configure Jest for TypeScript
+// Jest setup shared by every suite.
+
+import { resetChallengeCooldown } from '../challengeCooldown';
+
+// The bot-challenge back-off is module-level state, so a test that produces a
+// challenge would otherwise make later tests fail fast without a request.
+// Clearing it before each test keeps suites independent regardless of order.
+beforeEach(() => {
+  resetChallengeCooldown();
+});
+
 export {};

--- a/nodes/DuckDuckGo/challengeCooldown.ts
+++ b/nodes/DuckDuckGo/challengeCooldown.ts
@@ -1,0 +1,51 @@
+/**
+ * Short back-off after a DuckDuckGo bot-detection challenge.
+ *
+ * The block behind a challenge is scoped to the requesting IP and lasts tens of
+ * minutes, so every further request made during it is wasted, adds load to a
+ * service that has just said stop, and prolongs the block for everyone sharing
+ * that egress address — which on n8n Cloud or shared hosting is other tenants.
+ *
+ * Once a challenge is seen, requests are refused locally for a short window
+ * instead of being sent. The window is deliberately much shorter than the block
+ * itself: it throttles rather than blocks, so a single probe goes out roughly
+ * once per window and the node recovers within a window of the block lifting,
+ * rather than being sidelined for the block's full duration.
+ *
+ * State is module-level and therefore per n8n process. That is the correct
+ * scope: the block follows the process's outbound IP, not the workflow or item.
+ */
+
+/** How long to refuse requests locally after a challenge. */
+export const CHALLENGE_COOLDOWN_MS = 60_000;
+
+let cooldownUntil = 0;
+
+/** Record that a challenge was just observed, starting the back-off window. */
+export function noteChallenge(now: number = Date.now()): void {
+  cooldownUntil = now + CHALLENGE_COOLDOWN_MS;
+}
+
+/** Milliseconds left in the back-off window; 0 when requests may proceed. */
+export function getRemainingCooldownMs(now: number = Date.now()): number {
+  const remaining = cooldownUntil - now;
+  return remaining > 0 ? remaining : 0;
+}
+
+/**
+ * Human-readable reason to give when a request is refused locally, or null when
+ * there is no active back-off.
+ */
+export function getCooldownReason(now: number = Date.now()): string | null {
+  const remaining = getRemainingCooldownMs(now);
+  if (remaining === 0) return null;
+  const seconds = Math.ceil(remaining / 1000);
+  return `DuckDuckGo served a bot-detection challenge moments ago, so this request was not sent. `
+    + `The block applies to your n8n instance's IP address and typically lasts tens of minutes. `
+    + `Requests resume automatically in ${seconds}s; reduce how frequently this node runs.`;
+}
+
+/** Clear the back-off window. Intended for tests. */
+export function resetChallengeCooldown(): void {
+  cooldownUntil = 0;
+}

--- a/nodes/DuckDuckGo/challengeDetection.ts
+++ b/nodes/DuckDuckGo/challengeDetection.ts
@@ -22,6 +22,7 @@
  */
 
 import { DuckDuckGoError, DuckDuckGoErrorType } from './errors';
+import { noteChallenge } from './challengeCooldown';
 
 /**
  * Substrings identifying the challenge page. Each is structural (element id,
@@ -59,6 +60,9 @@ export function isChallengePage(body: unknown): boolean {
  * @param statusCode - HTTP status the challenge arrived with (typically 202).
  */
 export function createChallengeError(operation: string, statusCode?: number): DuckDuckGoError {
+  // Every challenge, however it is surfaced, starts the back-off window. Doing it
+  // here keeps the throwing and the non-throwing call sites consistent.
+  noteChallenge();
   return new DuckDuckGoError(
     `DuckDuckGo returned a bot-detection challenge instead of ${operation} results.`,
     DuckDuckGoErrorType.BOT_CHALLENGE,

--- a/nodes/DuckDuckGo/directSearch.ts
+++ b/nodes/DuckDuckGo/directSearch.ts
@@ -6,8 +6,9 @@
 import axios from 'axios';
 import { BROWSER_USER_AGENT } from './constants';
 import { assertNotChallenged } from './challengeDetection';
+import { getCooldownReason } from './challengeCooldown';
 import { extractVqd } from './vqdExtraction';
-import { DuckDuckGoError } from './errors';
+import { DuckDuckGoError, DuckDuckGoErrorType } from './errors';
 
 /**
  * Clean text by removing HTML entities and normalizing whitespace
@@ -107,6 +108,11 @@ export async function directWebSearch(query: string, options: {
   safeSearch?: string;
   maxResults?: number;
 } = {}): Promise<{ results: DirectSearchResult[] }> {
+  // A challenge was seen very recently; sending another request would only
+  // extend the block on this IP.
+  const cooling = getCooldownReason();
+  if (cooling) throw new DuckDuckGoError(cooling, DuckDuckGoErrorType.BOT_CHALLENGE);
+
   try {
     // Use POST method to DuckDuckGo HTML endpoint
     const response = await axios.post('https://html.duckduckgo.com/html/',
@@ -223,6 +229,9 @@ export async function directImageSearch(query: string, options: {
   safeSearch?: string;
   maxResults?: number;
 } = {}, vqdHint?: string): Promise<{ results: DirectImageResult[]; vqd: string }> {
+  const cooling = getCooldownReason();
+  if (cooling) throw new DuckDuckGoError(cooling, DuckDuckGoErrorType.BOT_CHALLENGE);
+
   try {
     const searchParams = new URLSearchParams({
       q: query,

--- a/nodes/DuckDuckGo/fallbackSearch.ts
+++ b/nodes/DuckDuckGo/fallbackSearch.ts
@@ -9,6 +9,7 @@ import { SearchOptions } from 'duck-duck-scrape';
 import axios from 'axios';
 import { BROWSER_USER_AGENT } from './constants';
 import { isChallengePage, createChallengeError } from './challengeDetection';
+import { getCooldownReason } from './challengeCooldown';
 
 export interface FallbackSearchResult {
   title: string;
@@ -147,6 +148,13 @@ export async function fallbackWebSearch(
   query: string,
   options: SearchOptions = {}
 ): Promise<FallbackSearchResponse> {
+  // The block is IP-scoped, so a fallback request during the back-off window
+  // would hit the same wall and prolong it.
+  const cooling = getCooldownReason();
+  if (cooling) {
+    return { success: false, noResults: true, results: [], challenged: true, error: cooling };
+  }
+
   try {
     const searchUrl = 'https://html.duckduckgo.com/html/';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.11.0",
+  "version": "32.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.11.0",
+      "version": "32.12.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.11.0",
+  "version": "32.12.0",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Completes the fallback-amplification fix started in #42 (32.10.0) — the last open item from the P0 work.

## Problem

Every request sent during a challenge block is wasted. The block follows the instance's **outbound IP**, lasts tens of minutes, and each extra request **prolongs it** — for everyone sharing that address, which on n8n Cloud means other tenants.

32.10.0 stopped the fallback *masking* a challenge, but could not stop it being *attempted*: for News and Video the primary is `duck-duck-scrape`, which fails opaquely, so a challenge is indistinguishable from any other failure at that point.

## Change

Once a challenge is seen, search requests are refused **locally** for about a minute instead of being sent, with an error stating how many seconds remain.

The window is deliberately far shorter than the block, so the node **throttles rather than stops**: roughly one probe per minute still goes out, and normal operation resumes within a minute of the block lifting rather than being sidelined for its full duration.

- `createChallengeError` starts the window, so every path that surfaces a challenge records it at **one choke point**.
- `directWebSearch` / `directImageSearch` throw during the window; `fallbackWebSearch` keeps its return-object contract and reports `challenged: true`.
- **This closes the gap:** a challenge seen by Web Search now holds back the News/Video fallback too.

## Design notes

- State is module-level, which is the **correct scope** — the block follows the process's outbound IP, not the workflow or the item.
- `jest.setup.ts` resets the window before every test, so suites stay order-independent now that challenge state persists in the module.

## Verification

`tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **354 tests / 17 suites** (10 new, none broken) — including that a challenge on one path stops the next request on another, and that requests resume once the window has passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)