### PR TITLE
docs: add importable example workflows; drop the duplicate packaged icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,18 @@ There is no user-configurable backend selector. Each operation type uses the mos
 - **Competitive intelligence**: Research competitors, products, or industries
 - **Automated content curation**: Build workflows that discover and process fresh content
 
+### Ready-made workflows
+
+Copy the JSON and paste it straight onto an n8n canvas (**Ctrl/Cmd+V**), or use **Import from File**.
+
+| Workflow | What it shows |
+|---|---|
+| [Research assistant](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/01-research-assistant.json) | Web Search with **Fetch Page Content** + metadata — full article text instead of snippets, ready to hand to an LLM |
+| [Query expansion](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/02-query-expansion.json) | **Search Suggestions** with `splitIntoItems`, looped into one Web Search per suggestion, with a **Wait** node so you stay under the rate limit |
+| [Daily news monitor](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/03-news-monitor.json) | Scheduled **News Search** with `timePeriod: d`, `retryOnFail`, and a filter that drops items carrying an `error` |
+
+Each one uses **On Error → Continue** on the search node, which is the recommended setting: a rate-limited search raises an error rather than returning an empty list, and continuing lets the rest of the run proceed.
+
 ---
 
 ## 🤝 Contributing

--- a/docs/examples/01-research-assistant.json
+++ b/docs/examples/01-research-assistant.json
@@ -1,0 +1,40 @@
+{
+  "name": "DuckDuckGo — Research assistant (search + full page text)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "a1b2c3d4-0001-4000-8000-000000000001",
+      "name": "When clicking Test workflow",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "operation": "search",
+        "query": "retrieval augmented generation best practices",
+        "webSearchOptions": {
+          "maxResults": 5,
+          "region": "wt-wt",
+          "fetchPageContent": true,
+          "pageContentMaxResults": 3,
+          "pageContentMaxLength": 3000,
+          "includePageMetadata": true
+        }
+      },
+      "id": "a1b2c3d4-0001-4000-8000-000000000002",
+      "name": "DuckDuckGo Search",
+      "type": "n8n-nodes-duckduckgo-search.duckDuckGo",
+      "typeVersion": 1,
+      "position": [220, 0],
+      "onError": "continueRegularOutput"
+    }
+  ],
+  "connections": {
+    "When clicking Test workflow": {
+      "main": [[{ "node": "DuckDuckGo Search", "type": "main", "index": 0 }]]
+    }
+  },
+  "pinData": {},
+  "settings": { "executionOrder": "v1" }
+}

--- a/docs/examples/02-query-expansion.json
+++ b/docs/examples/02-query-expansion.json
@@ -1,0 +1,89 @@
+{
+  "name": "DuckDuckGo — Query expansion (suggestions fan out into searches)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "a1b2c3d4-0002-4000-8000-000000000001",
+      "name": "When clicking Test workflow",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "operation": "autocomplete",
+        "autocompleteQuery": "how to reduce cloud costs",
+        "autocompleteOptions": {
+          "maxResults": 5,
+          "region": "us-en",
+          "splitIntoItems": true
+        }
+      },
+      "id": "a1b2c3d4-0002-4000-8000-000000000002",
+      "name": "Get Suggestions",
+      "type": "n8n-nodes-duckduckgo-search.duckDuckGo",
+      "typeVersion": 1,
+      "position": [220, 0]
+    },
+    {
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      },
+      "id": "a1b2c3d4-0002-4000-8000-000000000003",
+      "name": "Loop Over Suggestions",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [440, 0]
+    },
+    {
+      "parameters": {
+        "amount": 3
+      },
+      "id": "a1b2c3d4-0002-4000-8000-000000000004",
+      "name": "Wait (be a good citizen)",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [660, 120],
+      "webhookId": "a1b2c3d4-0002-4000-8000-00000000000w"
+    },
+    {
+      "parameters": {
+        "operation": "search",
+        "query": "={{ $json.suggestion }}",
+        "webSearchOptions": {
+          "maxResults": 3,
+          "region": "us-en"
+        }
+      },
+      "id": "a1b2c3d4-0002-4000-8000-000000000005",
+      "name": "Search Each Suggestion",
+      "type": "n8n-nodes-duckduckgo-search.duckDuckGo",
+      "typeVersion": 1,
+      "position": [880, 120],
+      "onError": "continueRegularOutput"
+    }
+  ],
+  "connections": {
+    "When clicking Test workflow": {
+      "main": [[{ "node": "Get Suggestions", "type": "main", "index": 0 }]]
+    },
+    "Get Suggestions": {
+      "main": [[{ "node": "Loop Over Suggestions", "type": "main", "index": 0 }]]
+    },
+    "Loop Over Suggestions": {
+      "main": [
+        [],
+        [{ "node": "Wait (be a good citizen)", "type": "main", "index": 0 }]
+      ]
+    },
+    "Wait (be a good citizen)": {
+      "main": [[{ "node": "Search Each Suggestion", "type": "main", "index": 0 }]]
+    },
+    "Search Each Suggestion": {
+      "main": [[{ "node": "Loop Over Suggestions", "type": "main", "index": 0 }]]
+    }
+  },
+  "pinData": {},
+  "settings": { "executionOrder": "v1" }
+}

--- a/docs/examples/03-news-monitor.json
+++ b/docs/examples/03-news-monitor.json
@@ -1,0 +1,72 @@
+{
+  "name": "DuckDuckGo — Daily news monitor",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "hours", "hoursInterval": 6 }]
+        }
+      },
+      "id": "a1b2c3d4-0003-4000-8000-000000000001",
+      "name": "Every 6 hours",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "operation": "searchNews",
+        "newsQuery": "open source AI",
+        "newsSearchOptions": {
+          "maxResults": 10,
+          "region": "us-en",
+          "timePeriod": "d",
+          "fetchPageContent": true,
+          "pageContentMaxResults": 3,
+          "pageContentMaxLength": 2000
+        }
+      },
+      "id": "a1b2c3d4-0003-4000-8000-000000000002",
+      "name": "DuckDuckGo News",
+      "type": "n8n-nodes-duckduckgo-search.duckDuckGo",
+      "typeVersion": 1,
+      "position": [220, 0],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 5000,
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "version": 2 },
+          "conditions": [
+            {
+              "id": "a1b2c3d4-0003-4000-8000-0000000000c1",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": "",
+              "operator": { "type": "string", "operation": "notExists", "singleValue": true }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "a1b2c3d4-0003-4000-8000-000000000003",
+      "name": "Only successful results",
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2.2,
+      "position": [440, 0]
+    }
+  ],
+  "connections": {
+    "Every 6 hours": {
+      "main": [[{ "node": "DuckDuckGo News", "type": "main", "index": 0 }]]
+    },
+    "DuckDuckGo News": {
+      "main": [[{ "node": "Only successful results", "type": "main", "index": 0 }]]
+    }
+  },
+  "pinData": {},
+  "settings": { "executionOrder": "v1" }
+}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "main": "dist/nodes/index.js",
   "scripts": {
     "build": "tsc && gulp build:icons",
-    "build:prod": "rimraf dist && npm run build && npm run postbuild && npm run clean-build",
-    "postbuild": "copyfiles -u 1 \"nodes/**/*.{svg,png}\" dist/",
+    "build:prod": "rimraf dist && npm run build && npm run clean-build",
     "clean-build": "node -e \"const fs=require('fs'); const path=require('path'); const glob=require('glob'); const files=glob.sync('dist/**/*.{tsbuildinfo,map}'); files.forEach(f => fs.existsSync(f) && fs.unlinkSync(f)); const toRemove=['dist/tests','dist/credentials'].concat(glob.sync('dist/**/__tests__',{onlyDirectories:true})); toRemove.forEach(d=>{if(fs.existsSync(d))fs.rmSync(d,{recursive:true});});\"",
     "verify-build": "node -e \"const fs=require('fs'); const path=require('path'); const assert=require('assert'); assert.ok(fs.existsSync(path.join(__dirname, 'dist/nodes/DuckDuckGo/DuckDuckGo.node.js')), 'Main node file missing'); assert.ok(fs.existsSync(path.join(__dirname, 'dist/nodes/DuckDuckGo/duckduckgo.svg')), 'Icon missing'); console.log('✅ Build verification successful')\"",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Examples

Three ready-made workflows under `docs/examples/`, linked from the README:

| Workflow | Shows |
|---|---|
| Research assistant | Web Search + **Fetch Page Content** + metadata — full article text instead of snippets |
| Query expansion | **Search Suggestions** with `splitIntoItems` → one Web Search per suggestion, with a **Wait** node so the rate limit is respected |
| Daily news monitor | Scheduled News Search, `retryOnFail`, and a filter that drops items carrying an `error` |

All three set **On Error → Continue**, which is the correct setting since 32.10.0: a rate-limited search now raises an error rather than returning an empty list.

README links are **absolute GitHub URLs** — the README is also rendered on the npm package page, where relative links are not reliable.

## Packaging fix

The published tarball carried the node icon **twice**:

- `gulp build:icons` → `dist/nodes/DuckDuckGo/duckduckgo.svg` (where the node actually looks)
- `postbuild` → `dist/DuckDuckGo/duckduckgo.svg` (stray — `copyfiles -u 1` strips the wrong leading directory)

`postbuild` also ran **twice**, because npm invokes it automatically after `build` and `build:prod` called it again explicitly.

Since the project's single svg is already covered by gulp, `postbuild` is removed. Tarball: **26 → 25 files**, stray directory gone, `verify-build` still green.

No runtime code changed. `lint` 0 · `build:prod` + `verify-build` OK · **354 tests / 17 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)