### PR TITLE
fix: gate the News and Video primaries during the back-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [32.12.1] - 2026-09-07
+
+### Fixed
+
+- **The back-off now gates the News and Video primaries too.** 32.12.0 refused requests during the back-off on the Web, Image and fallback paths, but News and Video call `duck-duck-scrape` first — so every execution still sent one request from an IP DuckDuckGo had already blocked, which is exactly what the back-off exists to prevent.
+- **A challenge reported by the fallback now reaches the user.** The News and Video error item was built from the earlier primary failure, so the bot-challenge message and its countdown were replaced by a generic error. The challenge message is now preferred, and the remaining-seconds text survives the typed error instead of being overwritten by its canned wording.
+
+### Documentation
+
+- Corrected the news-monitor example: it advertised `retryOnFail`, which never fires for News or Video because those operations emit an error item rather than failing the execution. It now branches on the `error` field, and the README says so.
+
+---
+
 ## [32.12.0] - 2026-09-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -821,9 +821,11 @@ Copy the JSON and paste it straight onto an n8n canvas (**Ctrl/Cmd+V**), or use 
 |---|---|
 | [Research assistant](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/01-research-assistant.json) | Web Search with **Fetch Page Content** + metadata — full article text instead of snippets, ready to hand to an LLM |
 | [Query expansion](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/02-query-expansion.json) | **Search Suggestions** with `splitIntoItems`, looped into one Web Search per suggestion, with a **Wait** node so you stay under the rate limit |
-| [Daily news monitor](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/03-news-monitor.json) | Scheduled **News Search** with `timePeriod: d`, `retryOnFail`, and a filter that drops items carrying an `error` |
+| [Daily news monitor](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/03-news-monitor.json) | Scheduled **News Search** with `timePeriod: d`, branching on whether DuckDuckGo reported an `error` so a rate-limited run is handled rather than silently skipped |
 
 Each one uses **On Error → Continue** on the search node, which is the recommended setting: a rate-limited search raises an error rather than returning an empty list, and continuing lets the rest of the run proceed.
+
+> **On `retryOnFail`:** News and Video catch their own failures and emit an item carrying an `error` field rather than failing the execution, so n8n's retry setting never fires for them. Branch on `error` — as the news monitor example does — instead of relying on retries.
 
 ---
 

--- a/docs/examples/03-news-monitor.json
+++ b/docs/examples/03-news-monitor.json
@@ -31,21 +31,27 @@
       "type": "n8n-nodes-duckduckgo-search.duckDuckGo",
       "typeVersion": 1,
       "position": [220, 0],
-      "retryOnFail": true,
-      "maxTries": 2,
-      "waitBetweenTries": 5000,
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
         "conditions": {
-          "options": { "caseSensitive": true, "version": 2 },
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 2
+          },
           "conditions": [
             {
               "id": "a1b2c3d4-0003-4000-8000-0000000000c1",
               "leftValue": "={{ $json.error }}",
               "rightValue": "",
-              "operator": { "type": "string", "operation": "notExists", "singleValue": true }
+              "operator": {
+                "type": "string",
+                "operation": "exists",
+                "singleValue": true
+              }
             }
           ],
           "combinator": "and"
@@ -53,10 +59,56 @@
         "options": {}
       },
       "id": "a1b2c3d4-0003-4000-8000-000000000003",
-      "name": "Only successful results",
-      "type": "n8n-nodes-base.filter",
+      "name": "Did DuckDuckGo report an error?",
+      "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [440, 0]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1b2c3d4-0003-4000-8000-0000000000e1",
+              "name": "alert",
+              "value": "={{ 'DuckDuckGo could not complete this run: ' + $json.error }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a1b2c3d4-0003-4000-8000-000000000004",
+      "name": "Handle the error",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [680, -110]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1b2c3d4-0003-4000-8000-0000000000e2",
+              "name": "headline",
+              "value": "={{ $json.title }}",
+              "type": "string"
+            },
+            {
+              "id": "a1b2c3d4-0003-4000-8000-0000000000e3",
+              "name": "articleText",
+              "value": "={{ $json.pageContent || $json.description }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a1b2c3d4-0003-4000-8000-000000000005",
+      "name": "Shape the article",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [680, 110]
     }
   ],
   "connections": {
@@ -64,7 +116,13 @@
       "main": [[{ "node": "DuckDuckGo News", "type": "main", "index": 0 }]]
     },
     "DuckDuckGo News": {
-      "main": [[{ "node": "Only successful results", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Did DuckDuckGo report an error?", "type": "main", "index": 0 }]]
+    },
+    "Did DuckDuckGo report an error?": {
+      "main": [
+        [{ "node": "Handle the error", "type": "main", "index": 0 }],
+        [{ "node": "Shape the article", "type": "main", "index": 0 }]
+      ]
     }
   },
   "pinData": {},

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -60,6 +60,7 @@ import { fallbackNewsSearch, fallbackVideoSearch } from './fallbackSearch';
 import { fetchPageContent, fetchPageContents } from './pageContent';
 import { getInstantAnswer } from './instantAnswer';
 import { getAutocomplete } from './autocomplete';
+import { getCooldownReason } from './challengeCooldown';
 
 // Sleep for a fixed amount of time
 function sleep(ms: number): Promise<void> {
@@ -1783,6 +1784,11 @@ export class DuckDuckGo implements INodeType {
           // Note: maxResults is handled during processing, not in search options
           const maxResults = newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS;
 
+          // A bot-challenge or back-off message explains the failure and says when
+          // it clears. Held outside the try so the catch can prefer it over the
+          // generic primary error, which would otherwise mask it.
+          let newsChallengeMessage: string | undefined;
+
           // Create a cache key based on operation and parameters
           const cacheKey = JSON.stringify({
             operation,
@@ -1824,6 +1830,15 @@ export class DuckDuckGo implements INodeType {
                   { query: newsQuery, options: searchOptions, cacheEnabled: enableCache }
                 );
                 console.log(JSON.stringify(logEntry));
+              }
+
+              // The back-off must gate the primary call too, not just the
+              // fallback: otherwise every execution still sends one request
+              // from an IP DuckDuckGo has already blocked.
+              const newsCooling = getCooldownReason();
+              if (newsCooling) {
+                newsChallengeMessage = newsCooling;
+                throw new NodeOperationError(this.getNode(), newsCooling, { itemIndex });
               }
 
               // Execute news search
@@ -1987,6 +2002,10 @@ export class DuckDuckGo implements INodeType {
                 time: searchOptions.time,
               });
 
+              if (fallbackResult.challenged && fallbackResult.error) {
+                newsChallengeMessage = fallbackResult.error;
+              }
+
               if (fallbackResult.success && fallbackResult.results.length > 0) {
                 // Relevance filter: keep only fallback results that contain at least one
                 // query token as an exact word token in their title or body.
@@ -2045,7 +2064,8 @@ export class DuckDuckGo implements INodeType {
             // Only emit the error item when the fallback also produced nothing
             if (results.length === 0) {
               // Create a user-friendly error message
-              const errorMessage = parseApiError(error instanceof Error ? error : new Error(String(error)), 'news search');
+              const errorMessage = newsChallengeMessage
+                ?? parseApiError(error instanceof Error ? error : new Error(String(error)), 'news search');
 
               // Log detailed error if debug is enabled
               if (debugMode) {
@@ -2126,6 +2146,10 @@ export class DuckDuckGo implements INodeType {
             }
           }
 
+          // Held outside the try so the catch can prefer it over the generic
+          // primary error (see the News branch for the reasoning).
+          let videoChallengeMessage: string | undefined;
+
           try {
             // If result is not in cache, execute the search
             if (!result) {
@@ -2138,6 +2162,12 @@ export class DuckDuckGo implements INodeType {
                   { query: videoQuery, options: searchOptions, cacheEnabled: enableCache }
                 );
                 console.log(JSON.stringify(logEntry));
+              }
+
+              const videoCooling = getCooldownReason();
+              if (videoCooling) {
+                videoChallengeMessage = videoCooling;
+                throw new NodeOperationError(this.getNode(), videoCooling, { itemIndex });
               }
 
               // Execute video search
@@ -2291,6 +2321,10 @@ export class DuckDuckGo implements INodeType {
                 safeSearch: searchOptions.safeSearch,
               });
 
+              if (fallbackResult.challenged && fallbackResult.error) {
+                videoChallengeMessage = fallbackResult.error;
+              }
+
               if (fallbackResult.success && fallbackResult.results.length > 0) {
                 // Convert fallback results to video search format
                 const videoResults = fallbackResult.results.map(item => ({
@@ -2327,7 +2361,8 @@ export class DuckDuckGo implements INodeType {
             // Only emit the error item when the fallback also produced nothing
             if (results.length === 0) {
               // Create a user-friendly error message
-              const errorMessage = parseApiError(error instanceof Error ? error : new Error(String(error)), 'video search');
+              const errorMessage = videoChallengeMessage
+                ?? parseApiError(error instanceof Error ? error : new Error(String(error)), 'video search');
 
               // Log detailed error if debug is enabled
               if (debugMode) {

--- a/nodes/DuckDuckGo/__tests__/DuckDuckGo.test.ts
+++ b/nodes/DuckDuckGo/__tests__/DuckDuckGo.test.ts
@@ -4,6 +4,7 @@ import * as duckDuckScrape from 'duck-duck-scrape';
 import * as cache from '../cache';
 import * as directSearch from '../directSearch';
 import * as fallbackSearch from '../fallbackSearch';
+import { noteChallenge } from '../challengeCooldown';
 
 
 // Mock the duck-duck-scrape library
@@ -1014,6 +1015,41 @@ describe('DuckDuckGo Node', () => {
         }
       ]
     };
+
+    /** What the real fallback returns while the back-off is active. */
+    const cooldownFallback = {
+      success: false,
+      noResults: true,
+      results: [],
+      challenged: true,
+      error: 'DuckDuckGo served a bot-detection challenge moments ago, so this request was not sent. Requests resume automatically in 60s.',
+    };
+
+    it('does not call the primary news client while cooling down, and surfaces the reason', async () => {
+      // Regression for two defects found in review of the first cooldown pass:
+      // the primary was not gated at all (so News still sent one request per
+      // execution from an already-blocked IP), and the challenge message the
+      // fallback returned was replaced by a generic primary error.
+      setupNodeParameters('searchNews', 'latest tech news');
+      (fallbackSearch.fallbackNewsSearch as jest.Mock).mockResolvedValue(cooldownFallback);
+      noteChallenge();
+
+      const result = await duckDuckGoNode.execute.call(mockExecuteFunction);
+
+      expect(duckDuckScrape.searchNews).not.toHaveBeenCalled();
+      expect(result[0][0].json.error).toContain('was not sent');
+    });
+
+    it('does not call the primary video client while cooling down, and surfaces the reason', async () => {
+      setupNodeParameters('searchVideos', 'some video');
+      (fallbackSearch.fallbackVideoSearch as jest.Mock).mockResolvedValue(cooldownFallback);
+      noteChallenge();
+
+      const result = await duckDuckGoNode.execute.call(mockExecuteFunction);
+
+      expect(duckDuckScrape.searchVideos).not.toHaveBeenCalled();
+      expect(result[0][0].json.error).toContain('was not sent');
+    });
 
     it('should return news search results successfully', async () => {
       // Set up node parameters

--- a/nodes/DuckDuckGo/directSearch.ts
+++ b/nodes/DuckDuckGo/directSearch.ts
@@ -111,7 +111,9 @@ export async function directWebSearch(query: string, options: {
   // A challenge was seen very recently; sending another request would only
   // extend the block on this IP.
   const cooling = getCooldownReason();
-  if (cooling) throw new DuckDuckGoError(cooling, DuckDuckGoErrorType.BOT_CHALLENGE);
+  if (cooling) {
+    throw new DuckDuckGoError(cooling, DuckDuckGoErrorType.BOT_CHALLENGE, { userMessage: cooling });
+  }
 
   try {
     // Use POST method to DuckDuckGo HTML endpoint
@@ -230,7 +232,9 @@ export async function directImageSearch(query: string, options: {
   maxResults?: number;
 } = {}, vqdHint?: string): Promise<{ results: DirectImageResult[]; vqd: string }> {
   const cooling = getCooldownReason();
-  if (cooling) throw new DuckDuckGoError(cooling, DuckDuckGoErrorType.BOT_CHALLENGE);
+  if (cooling) {
+    throw new DuckDuckGoError(cooling, DuckDuckGoErrorType.BOT_CHALLENGE, { userMessage: cooling });
+  }
 
   try {
     const searchParams = new URLSearchParams({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.12.0",
+  "version": "32.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.12.0",
+      "version": "32.12.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.12.0",
+  "version": "32.12.1",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Addresses both defects Codex raised on #44, plus the example-workflow issue raised on #45.

## 1. The back-off did not cover News or Video (P1)

32.12.0 refused requests on the Web, Image and fallback paths — but News and Video call `duck-duck-scrape` **first**. Every execution therefore still sent one request from an IP DuckDuckGo had already blocked, which is exactly what the back-off exists to prevent.

Both primaries are now gated.

## 2. The challenge message never reached the user (P2)

The News/Video error item was always built from the earlier primary failure via `parseApiError`, so the bot-challenge message and its countdown were replaced by a generic error — the user got no indication of *why* the search failed.

The message now travels in a variable held outside the `try`, and is preferred over the primary error when present.

**Implementation note:** the gates throw `NodeOperationError`, not a library error, per `node-execute-block-wrong-error-thrown` (which the first attempt tripped). Carrying the message in a variable rather than on the error type also removed a helper whose `instanceof` branch would have been unreachable.

## 3. The news example advertised a retry that cannot fire (#45)

`retryOnFail` never triggers for News or Video: those operations catch their own failures and emit an item carrying an `error` field rather than failing the execution. The example now branches on `error` with an **If** node, and the README states the limitation.

## Verification

`tsc` clean · `lint` 0 · `build:prod` + `verify-build` OK · **356 tests / 17 suites** — including two new regression tests asserting the primary client is **not called** during the back-off and that the reason reaches the output item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)