### PR TITLE
chore: publish from CI with npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Required for npm provenance: the OIDC token proves to the registry that
+      # this build really came from this repository and workflow.
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -23,6 +26,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -36,6 +40,19 @@ jobs:
 
       - name: Build distribution package
         run: npm pack
+
+      - name: Verify the tag matches package.json
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$PKG_VERSION" != "${{ steps.version.outputs.VERSION }}" ]; then
+            echo "Tag v${{ steps.version.outputs.VERSION }} does not match package.json ($PKG_VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           RAW_REF: ${{ github.ref_name }}
         run: |
           VERSION="${RAW_REF#v}"
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z.-]+)?(+[0-9A-Za-z.-]+)?$'; then
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$'; then
             echo "Refusing to release: tag '$RAW_REF' is not a SemVer release tag." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build project
-        run: npm run build
-
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Build distribution package
-        run: npm pack
 
       - name: Verify the tag matches package.json
         run: |
@@ -49,10 +43,40 @@ jobs:
             exit 1
           fi
 
+      # A prerelease must never land on the default dist-tag, or an ordinary
+      # `npm install` would start serving it.
+      - name: Determine the npm dist-tag
+        id: disttag
+        run: |
+          case "${{ steps.version.outputs.VERSION }}" in
+            *-*) echo "TAG=next"   >> $GITHUB_OUTPUT
+                 echo "PRERELEASE=true"  >> $GITHUB_OUTPUT ;;
+            *)   echo "TAG=latest" >> $GITHUB_OUTPUT
+                 echo "PRERELEASE=false" >> $GITHUB_OUTPUT ;;
+          esac
+
+      # Build here as well as via prepublishOnly, so that a rerun which skips
+      # publishing still has a clean dist to pack the release asset from.
+      - name: Build distribution
+        run: npm run build:prod
+
+      # npm refuses to republish an existing version, which would otherwise make
+      # a rerun fail here and never reach the release step.
       - name: Publish to npm with provenance
-        run: npm publish --provenance --access public
+        run: |
+          if npm view "n8n-nodes-duckduckgo-search@${{ steps.version.outputs.VERSION }}" version >/dev/null 2>&1; then
+            echo "Version ${{ steps.version.outputs.VERSION }} is already on npm - skipping publish."
+          else
+            npm publish --provenance --access public --tag "${{ steps.disttag.outputs.TAG }}"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Packed after the production build so the asset attached below is the
+      # same set of files that was published, not a plain build that also
+      # carries compiled tests and tsbuildinfo.
+      - name: Pack the release asset
+        run: npm pack
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -62,6 +86,6 @@ jobs:
           files: |
             n8n-nodes-duckduckgo-search-${{ steps.version.outputs.VERSION }}.tgz
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.disttag.outputs.PRERELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,17 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      # A tag can be pushed at any commit, including one that never passed
+      # review. Publishing from it would bypass branch protection, and an npm
+      # version cannot be taken back once published.
+      - name: Verify the tag is on main
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Refusing to publish: $GITHUB_SHA is not contained in origin/main." >&2
+            exit 1
+          fi
+
       - name: Verify the tag matches package.json
         run: |
           PKG_VERSION="$(node -p "require('./package.json').version")"
@@ -46,14 +57,17 @@ jobs:
       # A prerelease must never land on the default dist-tag, or an ordinary
       # `npm install` would start serving it.
       - name: Determine the npm dist-tag
-        id: disttag
         run: |
-          case "${{ steps.version.outputs.VERSION }}" in
+          # Only the part before "+" can carry a prerelease: a hyphen inside
+          # build metadata, as in 1.2.3+build-1, does not make it one.
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          case "${VERSION%%+*}" in
             *-*) echo "TAG=next"   >> $GITHUB_OUTPUT
                  echo "PRERELEASE=true"  >> $GITHUB_OUTPUT ;;
             *)   echo "TAG=latest" >> $GITHUB_OUTPUT
                  echo "PRERELEASE=false" >> $GITHUB_OUTPUT ;;
           esac
+        id: disttag
 
       # Build here as well as via prepublishOnly, so that a rerun which skips
       # publishing still has a clean dist to pack the release asset from.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # A tag name is attacker-controllable text and git accepts things like
+      # v$(cmd) as a valid ref. Anything derived from it is validated as strict
+      # SemVer here, and reaches later steps through the environment rather than
+      # being interpolated into a shell script by the expression syntax.
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        env:
+          RAW_REF: ${{ github.ref_name }}
+        run: |
+          VERSION="${RAW_REF#v}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z.-]+)?(+[0-9A-Za-z.-]+)?$'; then
+            echo "Refusing to release: tag '$RAW_REF' is not a SemVer release tag." >&2
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       # A tag can be pushed at any commit, including one that never passed
       # review. Publishing from it would bypass branch protection, and an npm
@@ -47,20 +59,23 @@ jobs:
           fi
 
       - name: Verify the tag matches package.json
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           PKG_VERSION="$(node -p "require('./package.json').version")"
-          if [ "$PKG_VERSION" != "${{ steps.version.outputs.VERSION }}" ]; then
-            echo "Tag v${{ steps.version.outputs.VERSION }} does not match package.json ($PKG_VERSION)" >&2
+          if [ "$PKG_VERSION" != "$VERSION" ]; then
+            echo "Tag v$VERSION does not match package.json ($PKG_VERSION)" >&2
             exit 1
           fi
 
       # A prerelease must never land on the default dist-tag, or an ordinary
       # `npm install` would start serving it.
       - name: Determine the npm dist-tag
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           # Only the part before "+" can carry a prerelease: a hyphen inside
           # build metadata, as in 1.2.3+build-1, does not make it one.
-          VERSION="${{ steps.version.outputs.VERSION }}"
           case "${VERSION%%+*}" in
             *-*) echo "TAG=next"   >> $GITHUB_OUTPUT
                  echo "PRERELEASE=true"  >> $GITHUB_OUTPUT ;;
@@ -77,14 +92,16 @@ jobs:
       # npm refuses to republish an existing version, which would otherwise make
       # a rerun fail here and never reach the release step.
       - name: Publish to npm with provenance
-        run: |
-          if npm view "n8n-nodes-duckduckgo-search@${{ steps.version.outputs.VERSION }}" version >/dev/null 2>&1; then
-            echo "Version ${{ steps.version.outputs.VERSION }} is already on npm - skipping publish."
-          else
-            npm publish --provenance --access public --tag "${{ steps.disttag.outputs.TAG }}"
-          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          DIST_TAG: ${{ steps.disttag.outputs.TAG }}
+        run: |
+          if npm view "n8n-nodes-duckduckgo-search@$VERSION" version >/dev/null 2>&1; then
+            echo "Version $VERSION is already on npm - skipping publish."
+          else
+            npm publish --provenance --access public --tag "$DIST_TAG"
+          fi
 
       # Packed after the production build so the asset attached below is the
       # same set of files that was published, not a plain build that also

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # A tag name is attacker-controllable text and git accepts things like
-      # v$(cmd) as a valid ref. Anything derived from it is validated as strict
-      # SemVer here, and reaches later steps through the environment rather than
-      # being interpolated into a shell script by the expression syntax.
+      # Two reasons this is validated rather than trusted. A tag name is
+      # attacker-controllable text and git accepts refs like v$(cmd), so nothing
+      # derived from it may be interpolated into a shell script. And npm
+      # canonicalises the manifest version before publishing, so a tag carrying
+      # build metadata or a leading-zero component would be published under a
+      # different version than the tag and the release asset claim. Only versions
+      # npm keeps verbatim are accepted.
       - name: Extract version from tag
         id: version
         env:
           RAW_REF: ${{ github.ref_name }}
         run: |
           VERSION="${RAW_REF#v}"
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$'; then
+          if ! printf '%s' "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$'; then
             echo "Refusing to release: tag '$RAW_REF' is not a SemVer release tag." >&2
             exit 1
           fi
@@ -74,9 +77,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          # Only the part before "+" can carry a prerelease: a hyphen inside
-          # build metadata, as in 1.2.3+build-1, does not make it one.
-          case "${VERSION%%+*}" in
+          case "$VERSION" in
             *-*) echo "TAG=next"   >> $GITHUB_OUTPUT
                  echo "PRERELEASE=true"  >> $GITHUB_OUTPUT ;;
             *)   echo "TAG=latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - 'v*'
 
+# Two tags pushed close together would otherwise race, and whichever job wrote
+# the dist-tag last would decide what `npm install` serves - even if it carried
+# the older version.
+concurrency:
+  group: npm-release
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Create Release
@@ -35,17 +42,20 @@ jobs:
       # attacker-controllable text and git accepts refs like v$(cmd), so nothing
       # derived from it may be interpolated into a shell script. And npm
       # canonicalises the manifest version before publishing, so a tag carrying
-      # build metadata or a leading-zero component would be published under a
-      # different version than the tag and the release asset claim. Only versions
-      # npm keeps verbatim are accepted.
+      # build metadata or a non-canonical prerelease identifier (1.0.0-01, which
+      # npm rewrites to 1.0.0-1) would be published under a different version
+      # than the tag and the release asset claim. Only versions npm keeps
+      # verbatim are accepted.
       - name: Extract version from tag
         id: version
         env:
           RAW_REF: ${{ github.ref_name }}
         run: |
           VERSION="${RAW_REF#v}"
-          if ! printf '%s' "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$'; then
-            echo "Refusing to release: tag '$RAW_REF' is not a SemVer release tag." >&2
+          NUM='(0|[1-9][0-9]*)'
+          IDENT="($NUM|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)"
+          if ! printf '%s' "$VERSION" | grep -Eq "^$NUM[.]$NUM[.]$NUM(-$IDENT([.]$IDENT)*)?$"; then
+            echo "Refusing to release: tag '$RAW_REF' is not a canonical SemVer release tag." >&2
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
@@ -72,36 +82,90 @@ jobs:
           fi
 
       # A prerelease must never land on the default dist-tag, or an ordinary
-      # `npm install` would start serving it.
+      # `npm install` would start serving it. Neither must a stable release that
+      # is older than the one `latest` already points at - a late patch on an
+      # older line would otherwise pull every unqualified install backwards.
       - name: Determine the npm dist-tag
+        id: disttag
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
+          PKG_NAME: n8n-nodes-duckduckgo-search
         run: |
           case "$VERSION" in
-            *-*) echo "TAG=next"   >> $GITHUB_OUTPUT
-                 echo "PRERELEASE=true"  >> $GITHUB_OUTPUT ;;
-            *)   echo "TAG=latest" >> $GITHUB_OUTPUT
-                 echo "PRERELEASE=false" >> $GITHUB_OUTPUT ;;
+            *-*)
+              echo "TAG=next" >> "$GITHUB_OUTPUT"
+              echo "PRERELEASE=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              CURRENT_LATEST="$(npm view "$PKG_NAME" dist-tags.latest 2>/dev/null || true)"
+              TAG="$(CURRENT_LATEST="$CURRENT_LATEST" node -e '
+                const next = process.env.VERSION;
+                const current = process.env.CURRENT_LATEST;
+                if (!current) { console.log("latest"); process.exit(0); }
+                const core = (v) => v.split("-")[0].split(".").map(Number);
+                const [a, b] = [core(next), core(current)];
+                for (let i = 0; i < 3; i++) {
+                  if (a[i] !== b[i]) {
+                    console.log(a[i] > b[i] ? "latest" : "previous");
+                    process.exit(0);
+                  }
+                }
+                console.log(current.includes("-") ? "latest" : "previous");
+              ')"
+              echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+              echo "PRERELEASE=false" >> "$GITHUB_OUTPUT"
+              ;;
           esac
-        id: disttag
 
       # Build here as well as via prepublishOnly, so that a rerun which skips
       # publishing still has a clean dist to pack the release asset from.
       - name: Build distribution
         run: npm run build:prod
 
-      # npm refuses to republish an existing version, which would otherwise make
-      # a rerun fail here and never reach the release step.
       - name: Publish to npm with provenance
+        id: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
           DIST_TAG: ${{ steps.disttag.outputs.TAG }}
+          PKG_NAME: n8n-nodes-duckduckgo-search
         run: |
-          if npm view "n8n-nodes-duckduckgo-search@$VERSION" version >/dev/null 2>&1; then
-            echo "Version $VERSION is already on npm - skipping publish."
-          else
+          if ! npm view "$PKG_NAME@$VERSION" version >/dev/null 2>&1; then
             npm publish --provenance --access public --tag "$DIST_TAG"
+            echo "FROM_THIS_RELEASE=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # npm refuses to republish an existing version, so a rerun must not
+          # fail here. But existence alone does not mean the registry holds the
+          # build from this commit - the version may have been published by
+          # hand, or from a different commit. Only the provenance attestation
+          # settles that, so check it instead of assuming.
+          echo "Version $VERSION is already on npm - checking which build it is."
+          ATT_URL="$(npm view "$PKG_NAME@$VERSION" dist.attestations.url 2>/dev/null || true)"
+          MATCHES=false
+          if [ -n "$ATT_URL" ] && curl -fsSL "$ATT_URL" -o attestation.json; then
+            MATCHES="$(node -e '
+              try {
+                const doc = JSON.parse(require("fs").readFileSync("attestation.json", "utf8"));
+                const slsa = (doc.attestations || []).find(
+                  (a) => a.predicateType === "https://slsa.dev/provenance/v1",
+                );
+                const payload = slsa.bundle.dsseEnvelope.payload;
+                const statement = JSON.parse(Buffer.from(payload, "base64").toString());
+                const source = statement.predicate.buildDefinition.resolvedDependencies[0];
+                console.log(String(source.digest.gitCommit === process.env.GITHUB_SHA));
+              } catch {
+                console.log("false");
+              }
+            ')"
+          fi
+          rm -f attestation.json
+          if [ "$MATCHES" = "true" ]; then
+            echo "The published build came from $GITHUB_SHA - nothing to do."
+            echo "FROM_THIS_RELEASE=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::npm already serves $VERSION, but not from $GITHUB_SHA. The published package was not built by this workflow and carries no provenance from it."
+            echo "FROM_THIS_RELEASE=false" >> "$GITHUB_OUTPUT"
           fi
 
       # Packed after the production build so the asset attached below is the
@@ -110,11 +174,29 @@ jobs:
       - name: Pack the release asset
         run: npm pack
 
+      # When the registry copy did not come from this run, the attached archive
+      # is not provably the published one. Say so on the release rather than
+      # letting the two look interchangeable.
+      - name: Compose the release body
+        env:
+          FROM_THIS_RELEASE: ${{ steps.publish.outputs.FROM_THIS_RELEASE }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          cp RELEASE_NOTES.md release-body.md
+          if [ "$FROM_THIS_RELEASE" != "true" ]; then
+            {
+              printf '\n---\n\n'
+              printf '> **Note:** `%s` was already on npm before this release ran, so it was not\n' "$VERSION"
+              printf '> published by this workflow and carries no provenance from it. The archive\n'
+              printf '> attached here is built from this tag and may differ from the published package.\n'
+            } >> release-body.md
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           name: "🎉 Release v${{ steps.version.outputs.VERSION }}"
-          body_path: RELEASE_NOTES.md
+          body_path: release-body.md
           files: |
             n8n-nodes-duckduckgo-search-${{ steps.version.outputs.VERSION }}.tgz
           draft: false

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn.lock
 
 # Internal working plan — kept local, not published
 PROJECT_PLAN.md
+release-body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Releases now publish from CI with npm provenance.** The tag-triggered workflow publishes the package itself, attaching a signed attestation that the tarball was built from this repository at a known commit. Publishing happens before the GitHub release is created, so a failed publish cannot leave a release advertising a version that never reached npm, and the workflow refuses to publish if the tag and `package.json` disagree. Setup and troubleshooting are documented in `docs/RELEASING.md`.
+
+---
+
 ## [32.12.1] - 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Releases now publish from CI with npm provenance.** The tag-triggered workflow publishes the package itself, attaching a signed attestation that the tarball was built from this repository at a known commit. Publishing happens before the GitHub release is created, so a failed publish cannot leave a release advertising a version that never reached npm, and the workflow refuses to publish if the tag and `package.json` disagree. Setup and troubleshooting are documented in `docs/RELEASING.md`.
+- **Releases now publish from CI with npm provenance.** The tag-triggered workflow publishes the package itself, attaching a signed attestation that the tarball was built from this repository at a known commit. It refuses to publish if the tag and `package.json` disagree, publishes before creating the GitHub release so a failed publish cannot leave a release advertising a version that never reached npm, and skips publishing when the version already exists so a rerun can still reach the release step. Prerelease tags go to the `next` dist-tag rather than `latest`. Setup and troubleshooting are documented in `docs/RELEASING.md`.
+
+### Fixed
+
+- **The release asset now matches what is published.** The workflow packed the tarball after a plain `npm run build`, so every GitHub release since v32.7.0 attached a 44-file archive containing compiled test files and `tsbuildinfo`, while npm received the 25-file production build. The asset is now packed after `build:prod`.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,10 +56,16 @@ Three things about that order matter:
   after a failure later in the job can still reach the release step. npm refuses
   to republish a version, which would otherwise make every rerun fail.
 
-- **The tag must be a SemVer release tag**, and nothing derived from it is
-  interpolated into a shell script. A tag name is attacker-controllable text and
-  git accepts refs like `v$(cmd)`, so the version is validated against a strict
-  SemVer pattern and passed to later steps through the environment.
+- **The tag must be a version npm will publish verbatim**, and nothing derived
+  from it is interpolated into a shell script. A tag name is attacker-controllable
+  text and git accepts refs like `v$(cmd)`, so the version is validated and then
+  passed to later steps through the environment.
+
+  The validation also rejects versions npm would silently rewrite: npm cleans the
+  manifest version before publishing, so `v33.0.0+build-1` would reach the
+  registry as `33.0.0` while the tag and the release asset still claimed the
+  build metadata. Leading-zero components such as `v01.2.3` are rejected for the
+  same reason. Tag exactly what will be published.
 - **The tagged commit must be on `main`.** A tag can be pushed at any commit,
   including one that never passed review; publishing from it would bypass branch
   protection, and an npm version cannot be withdrawn once published.
@@ -70,9 +76,7 @@ A tag like `v33.0.0-beta.1` is published under the `next` dist-tag and marked as
 a prerelease on GitHub. Without that, an ordinary `npm install` would start
 serving the prerelease, because npm defaults to `latest`.
 
-Only the part before a `+` decides this, so `v33.0.0+build-1` is treated as a
-stable release — a hyphen inside SemVer build metadata does not make a version a
-prerelease.
+Build metadata is not accepted at all, so the hyphen test is unambiguous.
 
 ## Verifying a release
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -40,12 +40,27 @@ Provenance needs npm to trust this repository. Do this once, on npmjs.com:
    git push origin vX.Y.Z
    ```
 
-The tag push triggers `release.yml`, which installs, builds, checks that the tag
-matches `package.json`, publishes to npm **with provenance**, and then creates
-the GitHub release with the packed tarball attached.
+The tag push triggers `release.yml`, which installs, checks that the tag matches
+`package.json`, runs the production build, publishes to npm **with provenance**,
+then packs and attaches the release asset.
 
-Publishing happens **before** the GitHub release is created, so a failed publish
-cannot leave a release advertising a version that never reached npm.
+Three things about that order matter:
+
+- **Publish runs before the GitHub release is created**, so a failed publish
+  cannot leave a release advertising a version that never reached npm.
+- **The asset is packed after the production build**, so what is attached to the
+  release is the same set of files that was published. Packing after a plain
+  `npm run build` produced a 44-file tarball carrying compiled tests and
+  `tsbuildinfo`, against the 25 files npm actually publishes.
+- **Publishing is skipped when the version already exists on npm**, so a rerun
+  after a failure later in the job can still reach the release step. npm refuses
+  to republish a version, which would otherwise make every rerun fail.
+
+### Prereleases
+
+A tag like `v33.0.0-beta.1` is published under the `next` dist-tag and marked as
+a prerelease on GitHub. Without that, an ordinary `npm install` would start
+serving the prerelease, because npm defaults to `latest`.
 
 ## Verifying a release
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,80 @@
+# Releasing
+
+Publishing runs in CI so every release carries **npm provenance** — a signed
+attestation that the tarball was built from this repository, by this workflow,
+at a specific commit. It also removes the manual `npm login` step, whose token
+expired between sessions often enough to be a nuisance.
+
+## One-time setup
+
+Provenance needs npm to trust this repository. Do this once, on npmjs.com:
+
+1. **Register the trusted publisher.**
+   Go to the package page → **Settings** → **Trusted publisher** → GitHub Actions, and enter:
+   - Organization / user: `samnodehi`
+   - Repository: `n8n-nodes-duckduckgo`
+   - Workflow filename: `release.yml`
+
+2. **Add a publish token as a repository secret.**
+   On npmjs.com create an **Automation** granular access token scoped to
+   `n8n-nodes-duckduckgo-search` with read+write. Then in GitHub:
+   **Settings → Secrets and variables → Actions → New repository secret**,
+   named `NPM_TOKEN`.
+
+   > Automation tokens bypass 2FA prompts, which is what makes an unattended
+   > publish possible. Keep it scoped to this one package.
+
+## Cutting a release
+
+1. Land everything on `main` and make sure CI is green.
+2. Bump the version and write the notes:
+   - `package.json` version
+   - a new section at the top of `CHANGELOG.md`
+   - a new section at the top of `RELEASE_NOTES.md` (the GitHub release body is
+     taken from this file)
+3. Merge that to `main`.
+4. Tag and push:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z - short summary"
+   git push origin vX.Y.Z
+   ```
+
+The tag push triggers `release.yml`, which installs, builds, checks that the tag
+matches `package.json`, publishes to npm **with provenance**, and then creates
+the GitHub release with the packed tarball attached.
+
+Publishing happens **before** the GitHub release is created, so a failed publish
+cannot leave a release advertising a version that never reached npm.
+
+## Verifying a release
+
+```bash
+npm view n8n-nodes-duckduckgo-search version
+```
+
+On the npm package page the version should show a **Provenance** section linking
+back to the workflow run and commit.
+
+## If the publish step fails
+
+- **`E404` on `PUT`** — npm returns 404 rather than 401 for an unauthorised
+  publish. It almost always means the token is missing, expired or out of scope,
+  not that the package or version is wrong.
+- **Provenance rejected** — check that `id-token: write` is still present in the
+  workflow permissions and that the trusted publisher entry still points at
+  `release.yml`.
+- The tag is already pushed at that point. Fix the cause and re-run the workflow
+  from the Actions tab rather than retagging.
+
+## Manual publish (fallback)
+
+Only if CI is unavailable:
+
+```powershell
+npm.cmd login
+npm.cmd publish
+```
+
+Use `npm.cmd`, not `npm` — PowerShell's execution policy blocks the `npm.ps1`
+shim on this machine. A manual publish produces **no provenance attestation**.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,6 +56,14 @@ Three things about that order matter:
   after a failure later in the job can still reach the release step. npm refuses
   to republish a version, which would otherwise make every rerun fail.
 
+  Existence alone is not treated as proof that the rerun is harmless: the
+  version could have been published by hand, or from a different commit. The
+  workflow reads the published version's provenance attestation and compares the
+  commit it records with the one being released. If they match, the skip is
+  silent. If they do not, the job still creates the GitHub release — that is the
+  manual-publish fallback below — but it logs a warning and appends a note to the
+  release body saying the attached archive was not the published one.
+
 - **The tag must be a version npm will publish verbatim**, and nothing derived
   from it is interpolated into a shell script. A tag name is attacker-controllable
   text and git accepts refs like `v$(cmd)`, so the version is validated and then
@@ -64,8 +72,9 @@ Three things about that order matter:
   The validation also rejects versions npm would silently rewrite: npm cleans the
   manifest version before publishing, so `v33.0.0+build-1` would reach the
   registry as `33.0.0` while the tag and the release asset still claimed the
-  build metadata. Leading-zero components such as `v01.2.3` are rejected for the
-  same reason. Tag exactly what will be published.
+  build metadata. Leading-zero components are rejected for the same reason, in
+  the version core (`v01.2.3`) and in numeric prerelease identifiers alike —
+  `v33.0.0-01` reaches npm as `33.0.0-1`. Tag exactly what will be published.
 - **The tagged commit must be on `main`.** A tag can be pushed at any commit,
   including one that never passed review; publishing from it would bypass branch
   protection, and an npm version cannot be withdrawn once published.
@@ -77,6 +86,14 @@ a prerelease on GitHub. Without that, an ordinary `npm install` would start
 serving the prerelease, because npm defaults to `latest`.
 
 Build metadata is not accepted at all, so the hyphen test is unambiguous.
+
+### Which release owns `latest`
+
+A stable release takes `latest` only if it is newer than the version `latest`
+already points at; an older one is published under `previous` instead. Two tags
+pushed close together would otherwise leave whichever job finished last in charge
+of what every unqualified `npm install` receives. The workflow also runs under a
+single concurrency group, so releases queue rather than overlap.
 
 ## Verifying a release
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,6 +56,10 @@ Three things about that order matter:
   after a failure later in the job can still reach the release step. npm refuses
   to republish a version, which would otherwise make every rerun fail.
 
+- **The tag must be a SemVer release tag**, and nothing derived from it is
+  interpolated into a shell script. A tag name is attacker-controllable text and
+  git accepts refs like `v$(cmd)`, so the version is validated against a strict
+  SemVer pattern and passed to later steps through the environment.
 - **The tagged commit must be on `main`.** A tag can be pushed at any commit,
   including one that never passed review; publishing from it would bypass branch
   protection, and an npm version cannot be withdrawn once published.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,11 +56,19 @@ Three things about that order matter:
   after a failure later in the job can still reach the release step. npm refuses
   to republish a version, which would otherwise make every rerun fail.
 
+- **The tagged commit must be on `main`.** A tag can be pushed at any commit,
+  including one that never passed review; publishing from it would bypass branch
+  protection, and an npm version cannot be withdrawn once published.
+
 ### Prereleases
 
 A tag like `v33.0.0-beta.1` is published under the `next` dist-tag and marked as
 a prerelease on GitHub. Without that, an ordinary `npm install` would start
 serving the prerelease, because npm defaults to `latest`.
+
+Only the part before a `+` decides this, so `v33.0.0+build-1` is treated as a
+stable release — a hyphen inside SemVer build metadata does not make a version a
+prerelease.
 
 ## Verifying a release
 


### PR DESCRIPTION
Releases were published by hand, which produced **no provenance attestation** and depended on a login token that kept expiring between sessions.

The tag-triggered workflow now publishes the package itself with `npm publish --provenance`, so each release carries a signed attestation that the tarball was built from this repository at a known commit.

## Changes

- `id-token: write` permission — this is what mints the attestation; without it `--provenance` fails.
- `registry-url` on setup-node so `NODE_AUTH_TOKEN` is picked up.
- **Publish runs before the GitHub release is created**, so a failed publish cannot leave a release advertising a version that never reached npm.
- The workflow **refuses to publish when the tag and `package.json` disagree**.
- `docs/RELEASING.md`: one-time trusted-publisher setup, release steps, how to verify provenance, and what the misleading `E404` on publish actually means (an auth problem, not a missing package).

## ⚠️ Two one-time actions needed before the next tag

1. **Register the trusted publisher** on npmjs.com → package Settings → Trusted publisher → GitHub Actions: `samnodehi` / `n8n-nodes-duckduckgo` / `release.yml`
2. **Add an `NPM_TOKEN` repository secret** — an npm **Automation** granular token scoped to this package (automation tokens bypass the 2FA prompt, which is what makes an unattended publish possible).

Until both exist, keep publishing manually per the fallback in the doc. Tagging before setup would fail the publish step — the tag is already pushed at that point, so fix and re-run from the Actions tab rather than retagging.

## Why it is worth doing regardless of verification

Provenance is also one of the blockers on n8n's verified-community-node checklist — `@n8n/scan-community-package` currently fails this package with *"not published with npm provenance"*. This clears that item and ends the recurring token expiry at the same time.

No runtime code changed. `lint` 0 · `build:prod` + `verify-build` OK · **356 tests / 17 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)