### PR TITLE
docs: make the example workflows submittable as n8n.io templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,13 +815,13 @@ There is no user-configurable backend selector. Each operation type uses the mos
 
 ### Ready-made workflows
 
-Copy the JSON and paste it straight onto an n8n canvas (**Ctrl/Cmd+V**), or use **Import from File**.
+Copy the JSON and paste it straight onto an n8n canvas (**Ctrl/Cmd+V**), or use **Import from File**. Each one carries sticky notes explaining what it does and how to adapt it.
 
 | Workflow | What it shows |
 |---|---|
-| [Research assistant](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/01-research-assistant.json) | Web Search with **Fetch Page Content** + metadata — full article text instead of snippets, ready to hand to an LLM |
-| [Query expansion](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/02-query-expansion.json) | **Search Suggestions** with `splitIntoItems`, looped into one Web Search per suggestion, with a **Wait** node so you stay under the rate limit |
-| [Daily news monitor](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/03-news-monitor.json) | Scheduled **News Search** with `timePeriod: d`, branching on whether DuckDuckGo reported an `error` so a rate-limited run is handled rather than silently skipped |
+| [Extract full article text from search results](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/01-research-assistant.json) | Web Search with **Fetch Page Content** + metadata — full article text instead of snippets, ready to hand to an LLM |
+| [Expand one keyword into multiple searches](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/02-query-expansion.json) | **Search Suggestions** with `splitIntoItems`, looped into one Web Search per suggestion, with a **Wait** node so you stay under the rate limit |
+| [Monitor news on a schedule](https://github.com/samnodehi/n8n-nodes-duckduckgo/blob/main/docs/examples/03-news-monitor.json) | Scheduled **News Search** with `timePeriod: d`, branching on whether DuckDuckGo reported an `error` so a rate-limited run is handled rather than silently skipped |
 
 Each one uses **On Error → Continue** on the search node, which is the recommended setting: a rate-limited search raises an error rather than returning an empty list, and continuing lets the rest of the run proceed.
 

--- a/docs/examples/01-research-assistant.json
+++ b/docs/examples/01-research-assistant.json
@@ -1,6 +1,19 @@
 {
-  "name": "DuckDuckGo — Research assistant (search + full page text)",
+  "name": "Extract full article text from DuckDuckGo web search results",
   "nodes": [
+    {
+      "parameters": {
+        "content": "## Extract full article text from DuckDuckGo web search results\n\nSearch results give you a title, a link and a two-line snippet. That is rarely enough to answer a question or to feed a language model. This template runs a DuckDuckGo web search and then fetches and extracts the readable body of the top results, so every item arrives with the article itself attached.\n\n### How it works\n1. **DuckDuckGo Search** runs one web search with **Fetch Page Content** enabled.\n2. For the first few results the node downloads the page and extracts the main article text with Mozilla Readability, dropping navigation, ads and boilerplate.\n3. **Include Page Metadata** adds site name, author, published date and language, so you can filter or cite before sending anything downstream.\n4. The node continues on error, so one unreachable page never stops the run.\n\n### Setup\n1. Self-hosted n8n only. Install the community node `n8n-nodes-duckduckgo-search` under **Settings → Community nodes**.\n2. No account, API key or credential is needed — DuckDuckGo is queried directly.\n3. Change the **Query** field and run.\n\n### Customization tips\n- Raise **Max Results** for breadth, **Page Content Max Results** for depth.\n- Put an AI Agent after the node: the extracted text is already clean enough to summarise or answer from.",
+        "height": 640,
+        "width": 560,
+        "color": 1
+      },
+      "id": "a1b2c3d4-0001-4000-8000-0000000000s1",
+      "name": "Overview",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-620, -180]
+    },
     {
       "parameters": {},
       "id": "a1b2c3d4-0001-4000-8000-000000000001",

--- a/docs/examples/02-query-expansion.json
+++ b/docs/examples/02-query-expansion.json
@@ -1,6 +1,45 @@
 {
-  "name": "DuckDuckGo — Query expansion (suggestions fan out into searches)",
+  "name": "Expand one keyword into multiple DuckDuckGo searches with autocomplete",
   "nodes": [
+    {
+      "parameters": {
+        "content": "## Expand one keyword into multiple DuckDuckGo searches\n\nA single query returns a single view of a topic. DuckDuckGo's own autocomplete knows what people actually search for around a keyword, so this template asks for those suggestions and then runs a real web search for each one — broader coverage from one input, with no API key anywhere.\n\n### How it works\n1. **Get Suggestions** calls the Search Suggestions operation with **Split Into Items** on, so each suggestion becomes its own item.\n2. **Loop Over Suggestions** takes them one at a time.\n3. **Wait** pauses three seconds between searches. DuckDuckGo rate-limits per IP and answers a burst with a bot-challenge page instead of results; this keeps the loop under that line.\n4. **Search Each Suggestion** runs a web search for that suggestion and loops back for the next.\n\n### Setup\n1. Self-hosted n8n only. Install the community node `n8n-nodes-duckduckgo-search` under **Settings → Community nodes**.\n2. No account, API key or credential is needed.\n3. Replace the seed query in **Get Suggestions** and run.\n\n### Customization tips\n- Fewer, faster searches: lower **Max Results** in Get Suggestions.\n- Feed the collected results into a Summarize or AI Agent node to merge the findings into one answer.",
+        "height": 700,
+        "width": 560,
+        "color": 1
+      },
+      "id": "a1b2c3d4-0002-4000-8000-0000000000s1",
+      "name": "Overview",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-620, -200]
+    },
+    {
+      "parameters": {
+        "content": "## Ask what people search for\nOne seed keyword becomes several real queries.",
+        "height": 300,
+        "width": 420,
+        "color": 7
+      },
+      "id": "a1b2c3d4-0002-4000-8000-0000000000s2",
+      "name": "Section - suggestions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [160, -180]
+    },
+    {
+      "parameters": {
+        "content": "## Search each one, politely\nThe Wait node keeps the loop under DuckDuckGo's per-IP rate limit.",
+        "height": 380,
+        "width": 500,
+        "color": 7
+      },
+      "id": "a1b2c3d4-0002-4000-8000-0000000000s3",
+      "name": "Section - searches",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [600, -60]
+    },
     {
       "parameters": {},
       "id": "a1b2c3d4-0002-4000-8000-000000000001",

--- a/docs/examples/03-news-monitor.json
+++ b/docs/examples/03-news-monitor.json
@@ -1,6 +1,45 @@
 {
-  "name": "DuckDuckGo — Daily news monitor",
+  "name": "Monitor news from DuckDuckGo on a schedule and handle rate limits",
   "nodes": [
+    {
+      "parameters": {
+        "content": "## Monitor news from DuckDuckGo on a schedule\n\nAn unattended news watch is only useful if it also notices when it stops working. This template checks DuckDuckGo News every six hours, pulls the readable body of the top stories, and routes a failed run to its own branch instead of letting it look like a quiet news day.\n\n### How it works\n1. **Every 6 hours** starts the run.\n2. **DuckDuckGo News** searches the last day (**Time Period: d**) and fetches the article text of the first few results.\n3. **Did DuckDuckGo report an error?** branches on the `error` field. DuckDuckGo rate-limits per IP; when that happens the node reports it rather than returning an empty list, and this If node is what makes the difference visible.\n4. **Handle the error** builds an alert message. **Shape the article** maps each story to `headline` and `articleText`.\n\n### Setup\n1. Self-hosted n8n only. Install the community node `n8n-nodes-duckduckgo-search` under **Settings → Community nodes**.\n2. No account, API key or credential is needed.\n3. Change the query, then connect the two outputs wherever you want them — Slack, email, a database.\n\n### Customization tips\n- **Time Period** accepts d, w, m and y.\n- Send the error branch somewhere you actually read. A monitor that fails silently is worse than none.",
+        "height": 760,
+        "width": 560,
+        "color": 1
+      },
+      "id": "a1b2c3d4-0003-4000-8000-0000000000s1",
+      "name": "Overview",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-700, -260]
+    },
+    {
+      "parameters": {
+        "content": "## Fetch, then check\nSearch the last day of news, then ask whether DuckDuckGo reported a problem.",
+        "height": 400,
+        "width": 580,
+        "color": 7
+      },
+      "id": "a1b2c3d4-0003-4000-8000-0000000000s2",
+      "name": "Section - fetch",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-60, -240]
+    },
+    {
+      "parameters": {
+        "content": "## Two outcomes\nTop: something went wrong.\nBottom: the stories, shaped for whatever comes next.",
+        "height": 620,
+        "width": 340,
+        "color": 7
+      },
+      "id": "a1b2c3d4-0003-4000-8000-0000000000s3",
+      "name": "Section - outcomes",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [620, -260]
+    },
     {
       "parameters": {
         "rule": {

--- a/docs/examples/SUBMITTING-TO-N8N-IO.md
+++ b/docs/examples/SUBMITTING-TO-N8N-IO.md
@@ -1,0 +1,186 @@
+# Submitting these templates to n8n.io/workflows
+
+Notes and ready-to-paste copy for publishing the workflows in this folder on
+[n8n.io/workflows](https://n8n.io/workflows/). Rules below were read from the
+n8n Creator hub on **2026-09-07**; n8n describe the creator programme as an
+ongoing project, so re-check before submitting.
+
+## What n8n requires
+
+From the [Creator hub](https://n8n.notion.site/n8n-Creator-hub-7bd2cbe0fce0449198ecb23ff4a2f76f)
+and its [template submission guidelines](https://n8n.notion.site/p/Template-submission-guidelines-9959894476734da3b402c90b124b1f77):
+
+- **A creator account**, registered at <https://creators.n8n.io/register>.
+  A new creator may have **one template under review at a time**, and can only
+  submit the next after the previous is approved. Three approved templates make
+  the account verified, after which templates can be submitted in batches of four.
+- **Community-node templates are accepted**, with two additions the guidelines
+  call out as a special case:
+  - a disclaimer that the template is **self-hosted only**, and
+  - a **workflow image at the top of the description**, because the canvas
+    preview does not render for community nodes.
+- **Sticky notes are mandatory** — per the
+  [sticky note guidelines](https://n8n.notion.site/Sticky-note-guidelines-for-templates-2aa5b6e0c94f8058b0aefddd02655887):
+  exactly one yellow overview sticky in the top-left corner, 100–300 words,
+  containing `### How it works` and `### Setup`; white section stickies (under
+  50 words) grouping the nodes of any workflow with four or more of them.
+  All three templates in this folder already satisfy this.
+- **Title format**: `Action verb` + the thing being manipulated +
+  `to/on/in/from where`, sentence-style capitalisation, no emoji, no hype. The
+  `name` field of each JSON is already written in that form.
+- **Description**: around 200 words, Markdown only (no HTML), with the sections
+  *Who's it for*, *How it works*, *How to set up*, *Requirements*,
+  *How to customize*.
+- No hardcoded credentials, no personal identifiers.
+
+## Before submitting
+
+1. Import the template into n8n and take a **screenshot of the canvas** with the
+   sticky notes visible. One image per template; it goes at the top of the
+   description, in place of the `![...]` line below.
+2. Run it once so the description matches what actually happens.
+3. Submit through the Creator Dashboard at <https://creators.n8n.io/login>.
+
+Suggested order, given the one-at-a-time limit: **1 → 3 → 2**. The first shows
+the capability nothing else in the library offers (search results with the
+article body already extracted), the news monitor has the broadest recurring
+use, and query expansion is the most niche of the three.
+
+---
+
+## Template 1 — Extract full article text from DuckDuckGo web search results
+
+File: `01-research-assistant.json`
+
+> ![Workflow canvas](REPLACE-WITH-SCREENSHOT)
+>
+> **Self-hosted n8n only.** This template uses the community node
+> `n8n-nodes-duckduckgo-search`, and community nodes cannot be installed on
+> n8n Cloud.
+
+### Who's it for
+
+Anyone who needs the *content* of search results rather than the results
+themselves: research assistants, RAG pipelines, content and SEO teams, and
+anyone feeding a language model something better than a two-line snippet.
+
+### How it works
+
+A single DuckDuckGo node runs a web search with **Fetch Page Content** enabled.
+For the top results it downloads each page and extracts the main article text
+with Mozilla Readability, so navigation, ads and boilerplate are dropped and
+what is left is the piece itself. **Include Page Metadata** adds site name,
+author, published date and language to every item, which is enough to filter by
+source or to cite properly before anything goes downstream. The node is set to
+continue on error, so a single unreachable page cannot end the run.
+
+### How to set up
+
+1. Install `n8n-nodes-duckduckgo-search` under **Settings → Community nodes**.
+2. There is nothing to authenticate. DuckDuckGo needs no account and no API key,
+   and the node sends no telemetry.
+3. Edit the **Query** field and run.
+
+### Requirements
+
+Self-hosted n8n, and the `n8n-nodes-duckduckgo-search` community node. No
+credentials, no paid service.
+
+### How to customize
+
+Raise **Max Results** for breadth and **Page Content Max Results** for depth.
+Add an AI Agent or Summarize node after the search — the extracted text is clean
+enough to answer from directly. DuckDuckGo rate-limits per IP, so on a schedule
+keep the searches spaced out.
+
+---
+
+## Template 2 — Expand one keyword into multiple DuckDuckGo searches with autocomplete
+
+File: `02-query-expansion.json`
+
+> ![Workflow canvas](REPLACE-WITH-SCREENSHOT)
+>
+> **Self-hosted n8n only.** This template uses the community node
+> `n8n-nodes-duckduckgo-search`, and community nodes cannot be installed on
+> n8n Cloud.
+
+### Who's it for
+
+SEO and content researchers, keyword analysts, and anyone building a research
+agent that should explore a topic rather than answer one narrow question.
+
+### How it works
+
+One seed keyword goes into DuckDuckGo's autocomplete, which returns what people
+actually search for around that term. With **Split Into Items** enabled each
+suggestion becomes its own item, and a batch loop then runs a real web search
+for every one of them. A **Wait** node pauses three seconds between searches:
+DuckDuckGo rate-limits per IP and answers a burst with a bot-challenge page
+instead of results, and this is what keeps the loop below that line. Each search
+is set to continue on error, so one blocked query does not end the run.
+
+### How to set up
+
+1. Install `n8n-nodes-duckduckgo-search` under **Settings → Community nodes**.
+2. There is nothing to authenticate — no account, no API key.
+3. Replace the seed query in **Get Suggestions** and run.
+
+### Requirements
+
+Self-hosted n8n, and the `n8n-nodes-duckduckgo-search` community node. No
+credentials, no paid service.
+
+### How to customize
+
+Lower **Max Results** in Get Suggestions for a shorter, faster run. Raise the
+Wait interval if you are running this often from one IP. Feed the collected
+results into a Summarize or AI Agent node to merge everything into one answer,
+or into a Google Sheet to build a keyword map.
+
+---
+
+## Template 3 — Monitor news from DuckDuckGo on a schedule and handle rate limits
+
+File: `03-news-monitor.json`
+
+> ![Workflow canvas](REPLACE-WITH-SCREENSHOT)
+>
+> **Self-hosted n8n only.** This template uses the community node
+> `n8n-nodes-duckduckgo-search`, and community nodes cannot be installed on
+> n8n Cloud.
+
+### Who's it for
+
+Anyone running an unattended watch on a topic: competitive intelligence, brand
+monitoring, PR, or a daily digest for a team channel.
+
+### How it works
+
+A schedule trigger fires every six hours and searches DuckDuckGo News over the
+last day, fetching the readable body of the top stories rather than just their
+headlines. The result then passes through an If node that checks for an `error`
+field. That branch is the point of the template: DuckDuckGo rate-limits per IP,
+and a blocked run should look different from a quiet news day. One output builds
+an alert you can send wherever you will see it; the other maps each story to a
+`headline` and `articleText` pair, ready for a summariser, a database or a chat
+message.
+
+### How to set up
+
+1. Install `n8n-nodes-duckduckgo-search` under **Settings → Community nodes**.
+2. There is nothing to authenticate — no account, no API key.
+3. Change the query, adjust the schedule, and connect the two outputs to
+   wherever you want them.
+
+### Requirements
+
+Self-hosted n8n, and the `n8n-nodes-duckduckgo-search` community node. No
+credentials, no paid service.
+
+### How to customize
+
+**Time Period** accepts `d`, `w`, `m` and `y`. Add more queries by duplicating
+the news node, or deduplicate against a datastore so a story is only reported
+once. Send the error branch somewhere you actually read — a monitor that fails
+silently is worse than no monitor.


### PR DESCRIPTION
Prepares the three example workflows in \`docs/examples/\` for submission to n8n.io/workflows, and records what that submission actually requires.

**What changed**

- Each workflow gains the sticky notes n8n mandates for templates: exactly one yellow overview sticky in the top-left corner (100-300 words, with \`### How it works\` and \`### Setup\`), plus white section stickies over the two workflows that have four or more nodes.
- Workflow titles rewritten into the required form - action verb, the thing being manipulated, where - in sentence case, no emoji.
- New \`docs/examples/SUBMITTING-TO-N8N-IO.md\`: the Creator hub rules as read on 2026-09-07, the two extra requirements a community-node template carries (self-hosted disclaimer, canvas image, because the preview does not render), and ~200-word description copy for each of the three.
- README table updated to the new titles.

**Verified**

- All three JSON files parse; no duplicate node names or ids; every connection endpoint resolves to a node that exists; no two sticky boxes overlap.
- Overview stickies measure 213, 205 and 218 words - inside the 100-300 range - and all three contain the two required headings.
- Sticky colour numbers are not documented anywhere, so 1 (yellow) and 7 (neutral) were read out of the installed n8n editor build, where \`--sticky--color--background--variant-1\` resolves to \`--color--yellow-*\` and \`variant-7\` to \`--color--neutral-*\`.

**Left to the maintainer**: a canvas screenshot per template (the description needs one at the top), and a creator account. A new creator may only have one template under review at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)