### PR TITLE
chore: release 32.12.2 and fix the release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,15 +174,38 @@ jobs:
       - name: Pack the release asset
         run: npm pack
 
-      # When the registry copy did not come from this run, the attached archive
-      # is not provably the published one. Say so on the release rather than
-      # letting the two look interchangeable.
+      # RELEASE_NOTES.md is a cumulative history, so attaching the whole file
+      # gave every release the notes of every version before it - v32.12.1 went
+      # out with 623 lines opening on the v32.12.0 heading. Only this version's
+      # section is used, and a missing section fails the release rather than
+      # publishing someone else's notes.
+      #
+      # The second half covers the other way the body can mislead: when the
+      # registry copy did not come from this run, the attached archive is not
+      # provably the published one, so the release says so.
       - name: Compose the release body
         env:
           FROM_THIS_RELEASE: ${{ steps.publish.outputs.FROM_THIS_RELEASE }}
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          cp RELEASE_NOTES.md release-body.md
+          node -e '
+            const fs = require("fs");
+            const heading = "# v" + process.env.VERSION;
+            const lines = fs.readFileSync("RELEASE_NOTES.md", "utf8").split(/\r?\n/);
+            const start = lines.findIndex(
+              (l) => l === heading || l.startsWith(heading + " "),
+            );
+            if (start === -1) {
+              console.error("RELEASE_NOTES.md has no \"" + heading + "\" section.");
+              process.exit(1);
+            }
+            let end = lines.length;
+            for (let i = start + 1; i < lines.length; i++) {
+              if (/^# v/.test(lines[i])) { end = i; break; }
+            }
+            const section = lines.slice(start, end).join("\n").replace(/\s*-{3,}\s*$/, "");
+            fs.writeFileSync("release-body.md", section.trim() + "\n");
+          '
           if [ "$FROM_THIS_RELEASE" != "true" ]; then
             {
               printf '\n---\n\n'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
             exit 1
           fi
 
+      # The lockfile carries the version twice and is easy to forget on a bump.
+      # Left stale, the next `npm install` on a checkout of the tag rewrites it
+      # and leaves a dirty worktree for no reason the reader can see.
       - name: Verify the tag matches package.json
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
@@ -78,6 +81,12 @@ jobs:
           PKG_VERSION="$(node -p "require('./package.json').version")"
           if [ "$PKG_VERSION" != "$VERSION" ]; then
             echo "Tag v$VERSION does not match package.json ($PKG_VERSION)" >&2
+            exit 1
+          fi
+          LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
+          LOCK_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+          if [ "$LOCK_VERSION" != "$VERSION" ] || [ "$LOCK_ROOT_VERSION" != "$VERSION" ]; then
+            echo "package-lock.json is stale ($LOCK_VERSION / $LOCK_ROOT_VERSION); run npm install --package-lock-only" >&2
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [32.12.2] - 2026-09-07
+
+No functional changes to the node. Release, documentation and example-workflow work only.
+
 ### Changed
 
-- **Releases now publish from CI with npm provenance.** The tag-triggered workflow publishes the package itself, attaching a signed attestation that the tarball was built from this repository at a known commit. It refuses to publish if the tag and `package.json` disagree, publishes before creating the GitHub release so a failed publish cannot leave a release advertising a version that never reached npm, and skips publishing when the version already exists so a rerun can still reach the release step. Prerelease tags go to the `next` dist-tag rather than `latest`. Setup and troubleshooting are documented in `docs/RELEASING.md`.
+- **Releases now publish from CI with npm provenance.** The tag-triggered workflow publishes the package itself, attaching a signed attestation that the tarball was built from this repository at a known commit. It refuses to publish if the tag and `package.json` disagree, publishes before creating the GitHub release so a failed publish cannot leave a release advertising a version that never reached npm, and skips publishing when the version already exists so a rerun can still reach the release step. Prerelease tags go to the `next` dist-tag rather than `latest`, and a stable tag takes `latest` only if it is newer than the version `latest` already points at. Setup and troubleshooting are documented in `docs/RELEASING.md`.
+- **The example workflows now carry sticky notes** explaining what each one does and how to adapt it, and their titles were rewritten to the form n8n's template library expects. `docs/examples/SUBMITTING-TO-N8N-IO.md` records the submission requirements.
 
 ### Fixed
 
 - **The release asset now matches what is published.** The workflow packed the tarball after a plain `npm run build`, so every GitHub release since v32.7.0 attached a 44-file archive containing compiled test files and `tsbuildinfo`, while npm received the 25-file production build. The asset is now packed after `build:prod`.
+- **The GitHub release body is now this version's notes only.** `RELEASE_NOTES.md` is a cumulative history and the whole file was attached, so v32.12.1 went out with 623 lines opening on the v32.12.0 heading. The release now uses the section matching the tag, and fails if that section is missing rather than publishing another version's notes.
+- **A tag npm would rewrite is now rejected.** npm canonicalises the manifest version before publishing, so a tag carrying build metadata (`v33.0.0+build-1` → `33.0.0`) or a non-canonical prerelease identifier (`v33.0.0-01` → `33.0.0-1`) would have reached the registry under a different version than the tag and the release asset claimed.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,72 @@
+# v32.12.2 — Signed releases, and example workflows worth importing
+
+**Release Date:** 2026-09-07
+
+No functional changes to the node. Everything here is about how the package reaches you and how
+easy it is to start using it.
+
+---
+
+## What changed
+
+**Releases are now published from CI with npm provenance.** Every future version carries a signed
+attestation saying which repository, which workflow and which commit produced the tarball. On the
+npm page it appears as a **Provenance** section linking back to the build. Publishing by hand from
+a laptop proved nothing about where a tarball came from; this does.
+
+**The release archive on GitHub now matches what npm receives.** Every release since v32.7.0
+attached a 44-file archive that also contained compiled test files, against the 25 files actually
+published. The archive is now packed from the production build.
+
+**The release notes on GitHub are now the notes for that version.** The v32.12.1 release carried
+623 lines opening on the v32.12.0 heading, because the whole cumulative history file was attached.
+
+**The three example workflows are now annotated.** Each carries sticky notes explaining what it
+does, how to set it up and what to change — visible the moment you paste it onto a canvas.
+
+## Why it matters
+
+For a community node the supply chain is the whole trust story: you install it into an instance
+that already holds your credentials. Provenance is what lets you check the package on npm came from
+the code you can read on GitHub, rather than taking a maintainer's word for it.
+
+## Upgrading
+
+Nothing to change. The node behaves exactly as it did in 32.12.1.
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.12.2
+```
+
+---
+
+# v32.12.1 — Back-off gating for News and Video
+
+**Release Date:** 2026-09-07
+
+A follow-up to 32.12.0, closing two gaps in the bot-detection back-off.
+
+---
+
+## What changed
+
+The back-off now gates the **News and Video primaries** as well. 32.12.0 refused requests during the
+back-off on the Web, Image and fallback paths, but News and Video call `duck-duck-scrape` first, so
+every execution still sent one request from an IP DuckDuckGo had already blocked — exactly what the
+back-off exists to prevent.
+
+A challenge reported by the **fallback** path now reaches you. The News and Video error item was
+built from the earlier primary failure, so the bot-challenge message and its countdown were replaced
+by a generic error.
+
+## Upgrading
+
+```bash
+npm install n8n-nodes-duckduckgo-search@32.12.1
+```
+
+---
+
 # v32.12.0 — Automatic back-off after a bot-detection challenge
 
 **Release Date:** 2026-09-07

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -29,9 +29,12 @@ Provenance needs npm to trust this repository. Do this once, on npmjs.com:
 1. Land everything on `main` and make sure CI is green.
 2. Bump the version and write the notes:
    - `package.json` version
+   - `package-lock.json`, via `npm install --package-lock-only` — it carries the
+     version twice, and the release refuses to publish while it is stale
    - a new section at the top of `CHANGELOG.md`
-   - a new section at the top of `RELEASE_NOTES.md` (the GitHub release body is
-     taken from this file)
+   - a new section at the top of `RELEASE_NOTES.md`, headed exactly
+     `# vX.Y.Z — short summary`. That section becomes the GitHub release body,
+     and the release fails if there is no section for the tag.
 3. Merge that to `main`.
 4. Tag and push:
 
@@ -41,13 +44,17 @@ Provenance needs npm to trust this repository. Do this once, on npmjs.com:
    ```
 
 The tag push triggers `release.yml`, which installs, checks that the tag matches
-`package.json`, runs the production build, publishes to npm **with provenance**,
-then packs and attaches the release asset.
+`package.json` and `package-lock.json`, runs the production build, publishes to
+npm **with provenance**, then packs and attaches the release asset with the
+notes for that version.
 
-Three things about that order matter:
+What that order buys, and what it refuses:
 
 - **Publish runs before the GitHub release is created**, so a failed publish
   cannot leave a release advertising a version that never reached npm.
+- **The release body is this version's section of `RELEASE_NOTES.md`**, not the
+  whole file. That file is a cumulative history, and attaching all of it gave
+  v32.12.1 a 623-line body opening on the v32.12.0 heading.
 - **The asset is packed after the production build**, so what is attached to the
   release is the same set of files that was published. Packing after a plain
   `npm run build` produced a 44-file tarball carrying compiled tests and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.12.1",
+  "version": "32.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.12.1",
+      "version": "32.12.2",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.12.1",
+  "version": "32.12.2",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Prepares the 32.12.2 release. Everything unreleased since v32.12.1 is documentation and CI, so this is a patch - and its real purpose is to put the new provenance pipeline through an actual release.

**Also fixes a defect found while preparing it.** \`RELEASE_NOTES.md\` is a cumulative history file and the workflow attached all of it as the release body, so **v32.12.1 went out with 623 lines opening on the \`# v32.12.0\` heading** - and had no section of its own at all. The body is now the section matching the tag, with the trailing separator stripped, and a missing section fails the release instead of shipping another version's notes.

**Verified**

- The extractor was pulled out of the workflow file and run against the real \`RELEASE_NOTES.md\`: 39 / 24 / 47 lines for 32.12.2 / 32.12.1 / 32.12.0, and a version with no section exits 1 with a clear message.
- The missing v32.12.1 section is backfilled from its changelog entry.
- YAML parses, all 9 \`run\` blocks pass \`bash -n\`, no \`${{ }}\` inside any \`run\`.
- \`npm test\`: 356 passed, 17 suites. \`npm run lint\`: clean.

**Blocked until the maintainer acts**: the tag must not be pushed before the npm trusted publisher is registered and the \`NPM_TOKEN\` secret exists, or the publish step fails with E404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)