### PR TITLE
fix(release): publish over OIDC, with an npm new enough to do it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,15 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      # Trusted publishing needs npm 11.5.1 or later; Node 22 still bundles
+      # npm 10, which authenticates with a token and would fail here with no
+      # token to use. Requested explicitly rather than left to whichever npm a
+      # Node release happens to carry.
+      - name: Use an npm that can publish over OIDC
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
       - name: Install dependencies
         run: npm ci
 
@@ -131,10 +140,12 @@ jobs:
       - name: Build distribution
         run: npm run build:prod
 
+      # No token: the trusted publisher registered on npm authenticates this
+      # workflow over OIDC, using a short-lived credential nothing has to store
+      # or rotate. The id-token permission above is what makes that possible.
       - name: Publish to npm with provenance
         id: publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
           DIST_TAG: ${{ steps.disttag.outputs.TAG }}
           PKG_NAME: n8n-nodes-duckduckgo-search

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,22 +7,24 @@ expired between sessions often enough to be a nuisance.
 
 ## One-time setup
 
-Provenance needs npm to trust this repository. Do this once, on npmjs.com:
+**One step, and no token anywhere.** Register the trusted publisher on npmjs.com:
+package page → **Settings** → **Trusted publisher** → GitHub Actions, and enter:
 
-1. **Register the trusted publisher.**
-   Go to the package page → **Settings** → **Trusted publisher** → GitHub Actions, and enter:
-   - Organization / user: `samnodehi`
-   - Repository: `n8n-nodes-duckduckgo`
-   - Workflow filename: `release.yml`
+- Organization / user: `samnodehi`
+- Repository: `n8n-nodes-duckduckgo`
+- Workflow filename: `release.yml`
 
-2. **Add a publish token as a repository secret.**
-   On npmjs.com create an **Automation** granular access token scoped to
-   `n8n-nodes-duckduckgo-search` with read+write. Then in GitHub:
-   **Settings → Secrets and variables → Actions → New repository secret**,
-   named `NPM_TOKEN`.
+That is the whole setup. From then on the workflow authenticates over OIDC with a
+short-lived credential minted per run, so there is no `NPM_TOKEN` secret to
+create, scope, rotate or leak — and nothing to expire between releases.
 
-   > Automation tokens bypass 2FA prompts, which is what makes an unattended
-   > publish possible. Keep it scoped to this one package.
+Two requirements make it work, both already in `release.yml`:
+
+- **`id-token: write`** in the job permissions, which lets GitHub mint the OIDC
+  token npm verifies.
+- **npm 11.5.1 or later.** Node 22 still bundles npm 10, which only knows how to
+  authenticate with a token, so the workflow installs a newer npm before
+  publishing.
 
 ## Cutting a release
 
@@ -114,11 +116,14 @@ back to the workflow run and commit.
 ## If the publish step fails
 
 - **`E404` on `PUT`** — npm returns 404 rather than 401 for an unauthorised
-  publish. It almost always means the token is missing, expired or out of scope,
-  not that the package or version is wrong.
+  publish, so it almost never means the package or version is wrong. Check the
+  trusted publisher entry first: the workflow filename there must be exactly
+  `release.yml`, and the repository must match.
+- **`ENEEDAUTH`, or npm asking for a token** — the npm running the publish is
+  older than 11.5.1 and does not speak OIDC. Look at the version printed by the
+  "Use an npm that can publish over OIDC" step.
 - **Provenance rejected** — check that `id-token: write` is still present in the
-  workflow permissions and that the trusted publisher entry still points at
-  `release.yml`.
+  workflow permissions.
 - The tag is already pushed at that point. Fix the cause and re-run the workflow
   from the Actions tab rather than retagging.
 


### PR DESCRIPTION
The maintainer could not find **Settings → Secrets and variables** on the repository, which turned out to be the right question to ask: with a trusted publisher registered, **there is no secret to create.**

**What npm documents** ([trusted publishers](https://docs.npmjs.com/trusted-publishers)): once the publisher is registered, the workflow authenticates over OIDC with a short-lived credential minted per run — "an npm token is no longer necessary" — and provenance attestations are generated automatically for a public package. The requirements are \`id-token: write\` (already present) and **npm CLI 11.5.1 or later**.

**And that last requirement is why this was broken.** \`node-version: 22\` still bundles **npm 10**, which only knows token authentication. With the \`NPM_TOKEN\` secret absent, \`NODE_AUTH_TOKEN\` would have resolved to an empty string and the publish would have failed with \`ENEEDAUTH\` or \`E404\` — after the tag was already pushed.

**Changes**

- New step installs \`npm@^11.5.1\` and prints the version, so a regression is visible in the log rather than surfacing as an auth error.
- \`NODE_AUTH_TOKEN\` / \`NPM_TOKEN\` removed entirely; neither appears anywhere in the workflow now.
- \`docs/RELEASING.md\`: setup is one action on npmjs.com, no token step. Troubleshooting now covers the OIDC failure modes.

No version bump — 32.12.2 is staged on \`main\` but not yet tagged, so this folds into it.

**Verified**: YAML parses; permissions still \`contents: write\` + \`id-token: write\`; no \`NODE_AUTH_TOKEN\` or \`NPM_TOKEN\` string remains; all 10 \`run\` blocks pass \`bash -n\`; no \`${{ }}\` inside any \`run\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)