### PR TITLE
docs: lead the README with the rate-limit behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Image Search now reports a bot-detection challenge instead of returning nothing.** The challenge check ran only on the page fetched to obtain the VQD token, not on the `i.js` request that actually carries the results — and it was skipped entirely when a caller supplied a token, as pagination does. A challenge arriving there is HTML in place of JSON, which has no `results` property and so parsed to an empty set: the exact silent failure 32.10.0 was written to end, still live on one path. It now raises the challenge error and starts the local back-off like every other search path.
+
+### Changed
+
+- **The README leads with the rate-limit behaviour** rather than explaining it 500 lines in, so the first thing a reader learns is what an empty result set does and does not mean.
+
 ---
 
 ## [32.12.2] - 2026-09-07

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@
 
 An n8n community node for DuckDuckGo search. Search the web, find images, discover news, and explore videos — no API key required, no outbound telemetry.
 
+> ### If a search comes back with a rate-limit error, that is the node working
+>
+> DuckDuckGo rate-limits by IP address and answers a client it considers automated
+> with a human-verification page — served as **HTTP 202**, which ordinary HTTP clients
+> read as success. Nodes that do not check for it parse that page, find nothing, and
+> hand back an empty array, so a block looks exactly like a query with no results.
+>
+> This node recognises that page and says so, then **backs off locally for about a
+> minute** instead of sending requests that would only extend the block. Datacenter and
+> shared IPs — n8n Cloud, most VPS hosts, CI — hit it soonest. An empty array from this
+> node means no results, and nothing else.
+>
+> Details, and how to stay under the limit: [Bot-detection challenge](#bot-detection-challenge-rate-limiting).
+
 ## ✨ Features
 
 - **Four search types**: Web, Image, News, Video

--- a/nodes/DuckDuckGo/__tests__/challengeDetection.test.ts
+++ b/nodes/DuckDuckGo/__tests__/challengeDetection.test.ts
@@ -185,6 +185,42 @@ describe('directImageSearch challenge handling', () => {
       errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
     });
   });
+
+  it('reports a challenge served by i.js after the VQD page succeeded', async () => {
+    // The bootstrap page answers normally and yields a token; the block lands
+    // on the request that would have carried results.
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 200, data: '<script>vqd="3-123456789012345"</script>' })
+      .mockResolvedValueOnce({ status: 202, data: CHALLENGE_HTML });
+
+    await expect(directImageSearch('cats')).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+  });
+
+  it('reports a challenge on i.js even when the VQD page was skipped', async () => {
+    // With a supplied token there is no bootstrap request at all, so this was
+    // the path with no challenge check whatsoever.
+    mockedAxios.get.mockResolvedValueOnce({ status: 202, data: CHALLENGE_HTML });
+
+    await expect(
+      directImageSearch('cats', {}, '3-supplied-token'),
+    ).rejects.toMatchObject({
+      errorType: DuckDuckGoErrorType.BOT_CHALLENGE,
+    });
+  });
+
+  it('leaves a genuine empty image response reported as no results', async () => {
+    // Parsed JSON is never a challenge page, so an honest empty answer must
+    // still come back as an empty set rather than an error.
+    mockedAxios.get
+      .mockResolvedValueOnce({ status: 200, data: '<script>vqd="3-123456789012345"</script>' })
+      .mockResolvedValueOnce({ status: 200, data: { results: [] } });
+
+    const output = await directImageSearch('xzqwerty99zz');
+
+    expect(output.results).toHaveLength(0);
+  });
 });
 
 describe('fallbackWebSearch challenge handling', () => {

--- a/nodes/DuckDuckGo/directSearch.ts
+++ b/nodes/DuckDuckGo/directSearch.ts
@@ -321,6 +321,17 @@ export async function directImageSearch(query: string, options: {
       }
     }
 
+    // `i.js` is the request that actually carries results, and it is the one a
+    // block lands on: DuckDuckGo answers it with the challenge page as HTML
+    // instead of JSON, which has no `results` property and so parses to an
+    // empty set. Checking only the VQD bootstrap above missed that entirely,
+    // and missed it completely when a caller supplied `vqdHint` and skipped the
+    // bootstrap. A genuine empty answer is parsed JSON, which
+    // `isChallengePage` never matches.
+    if (results.length === 0) {
+      assertNotChallenged(imageResponse.data, imageResponse.status, 'image search');
+    }
+
     return { results, vqd };
   } catch (error) {
     console.error('Direct image search error:', error.message);


### PR DESCRIPTION
From the [eligibility thread](https://community.n8n.io/t/verified-community-node-three-eligibility-questions-before-a-zero-dependency-rewrite/311936): a maintainer who recently went through n8n verification pointed out that the anomaly-page handling belongs at the top of the README rather than where a reviewer has to discover it.

> A reviewer who hits the rate limit and sees a clear "DuckDuckGo returned an anomaly page" message is watching your error handling work, which is a very different impression from a node that appears to return nothing. Said up front, it reads as robustness. Said after the fact, it reads as an excuse.

He is right, and the same argument applies to every user who opens the README after their first empty run. The explanation was at line 516.

It now sits directly under the intro: what the HTTP 202 anomaly page is, why a node that does not check for it returns a silent empty array, that this node backs off locally instead of extending the block, which IPs hit it first, and that an empty array here means no results and nothing else.

**Verified**: all nine internal anchors in the README resolve, including the new link to the full section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)