### PR TITLE
feat: add local ranking rules for search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New option: Ranking Rules.** Reorder or drop results by where they came from, applied locally to results the node has already fetched — no extra requests, no service, nothing leaves the process. Available on Web, News and Video Search. Each rule matches a **Domain** (subdomains included) or a **URL Contains** substring, and **Boosts**, **Downranks** or **Discards** what it matches.
+
+  Rules are checked in order and the first match wins, so a boost for `docs.example.com` above a discard for `example.com` keeps the documentation and drops the rest — something no fixed precedence between effects could express. Ordering is three stable buckets rather than a score, so there is no weight to tune and unmatched results stay exactly where DuckDuckGo put them. Rules run **before** the cut to `maxResults`, so asking for ten and discarding a domain still returns ten; `position` is renumbered to match. A result with no URL, or one that does not parse, is never discarded by a rule it had no chance to match.
+
 ---
 
 ## [32.13.0] - 2026-09-09

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ An n8n community node for DuckDuckGo search. Search the web, find images, discov
 - **Extract Page Content operation**: Give any URL → clean main text + metadata (a "read any page" tool for AI Agents)
 - **Instant Answer operation**: Direct answers, abstracts, and definitions from DuckDuckGo's free Instant Answer API
 - **Search Suggestions operation**: Query autocomplete from DuckDuckGo's suggestion endpoint — the surface least affected by rate limiting
+- **Ranking rules**: Boost, downrank or discard results by domain or URL, applied locally before the result limit — no extra requests
 
 ---
 
@@ -500,6 +501,56 @@ Cache is in-memory only and is not shared across n8n worker processes or restart
 | `viewCount` | string | View count (as string) |
 | `isFallback` | boolean | `true` if result came from fallback path |
 | `sourceType` | string | Always `"video"` |
+
+---
+
+## 🎯 Ranking Rules
+
+Search engines rank for everybody. A workflow usually wants something narrower —
+only documentation sites, never the content farms that copy them, this vendor's
+own pages before the aggregators.
+
+**Ranking Rules** does that locally, on results the node has already fetched.
+Available on Web, News and Video Search under **Options → Ranking Rules**.
+
+| Field | Meaning |
+|---|---|
+| **Match** | `Domain` (the site, subdomains included) or `URL Contains` (any text in the URL) |
+| **Value** | `example.com` — which also matches `www.example.com` and `docs.example.com`. For URL Contains, a substring such as `/amp/`. |
+| **Effect** | **Boost** (move above the others), **Downrank** (move below), **Discard** (remove) |
+
+### How it behaves
+
+- **Rules are checked in order and the first match wins.** Put specific rules
+  above broad ones: a *Boost* on `docs.example.com` written above a *Discard* on
+  `example.com` keeps the documentation and drops the rest of the site. No fixed
+  precedence between effects could express that.
+- **Ordering is three buckets, not a score.** Boosted results keep their order
+  among themselves and move above everything else, downranked ones likewise
+  below, and anything unmatched stays exactly where DuckDuckGo put it. There is
+  no weight to tune.
+- **Rules run before Maximum Results.** Ask for 10 with a rule that discards a
+  domain and you still get 10, filled from further down the list — not 7. This
+  is the reason to do it here rather than in a Filter node afterwards.
+- **`position` is renumbered** to match the order you actually receive.
+- **A result the rules cannot judge is kept.** A result with no URL, or one that
+  does not parse, is never discarded by a rule it had no chance to match.
+- Rules apply to fallback results too, since which site a result came from does
+  not depend on which path fetched it.
+
+Nothing here contacts anything. No rule causes a request, and none of this is
+sent anywhere — it is applied to the list already in memory.
+
+### Example
+
+Research that should prefer primary sources and never return aggregators:
+
+| Match | Value | Effect |
+|---|---|---|
+| Domain | `arxiv.org` | Boost |
+| Domain | `pinterest.com` | Discard |
+| Domain | `quora.com` | Discard |
+| URL Contains | `/amp/` | Downrank |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,10 @@ Available on Web, News and Video Search under **Options → Ranking Rules**.
 Nothing here contacts anything. No rule causes a request, and none of this is
 sent anywhere — it is applied to the list already in memory.
 
+> Two things rules do **not** apply to: **Image Search**, which has no ranking
+> option, and **Return Raw Results**, which by definition returns DuckDuckGo's
+> response before the node processes it.
+
 ### Example
 
 Research that should prefer primary sources and never return aggregators:

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -25,6 +25,7 @@ import {
 // Import our direct search implementations
 import { directWebSearch, directImageSearch, getSafeSearchString } from './directSearch';
 import { takeStoredVqd, storeVqd } from './vqdStore';
+import { applyRankingRules, rulesFromOptions, rankingRulesProperty } from './resultRanking';
 
 // Use duck-duck-scrape types directly
 
@@ -455,6 +456,7 @@ export class DuckDuckGo implements INodeType {
           },
         },
         options: [
+          rankingRulesProperty,
           {
             displayName: 'Maximum Results',
             name: 'maxResults',
@@ -862,6 +864,7 @@ export class DuckDuckGo implements INodeType {
           },
         },
         options: [
+          rankingRulesProperty,
           {
             displayName: 'Maximum Results',
             name: 'maxResults',
@@ -1057,6 +1060,7 @@ export class DuckDuckGo implements INodeType {
           },
         },
         options: [
+          rankingRulesProperty,
           {
             displayName: 'Maximum Results',
             name: 'maxResults',
@@ -1319,6 +1323,7 @@ export class DuckDuckGo implements INodeType {
           }
 
           const options = this.getNodeParameter('webSearchOptions', itemIndex, {}) as {
+            rankingRules?: unknown;
             maxResults?: number;
             region?: string;
             safeSearch?: number;
@@ -1434,9 +1439,17 @@ export class DuckDuckGo implements INodeType {
               };
 
               // Note: Direct search doesn't support pagination without VQD token
-              // Limit results to what we got from the first request
+              // Limit results to what we got from the first request.
+              //
+              // Ranking rules make this cut premature: a result discarded by a
+              // rule has to be replaced by one further down the list, and one
+              // that was cut here is not there to be promoted. When rules are
+              // configured the list is left whole and the cut happens after
+              // ranking instead, which is the only order in which "give me ten"
+              // and "never from this site" can both hold.
               const maxResults = options.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS;
-              if (result.results && result.results.length > maxResults) {
+              const hasRankingRules = rulesFromOptions(options.rankingRules).length > 0;
+              if (!hasRankingRules && result.results && result.results.length > maxResults) {
                 result.results = result.results.slice(0, maxResults);
               }
 
@@ -1499,7 +1512,12 @@ export class DuckDuckGo implements INodeType {
               } else {
                 // Process and return the results with enhanced data
                 const maxResults = options.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS;
-                results = processWebSearchResults(result.results as any, itemIndex, result).slice(0, maxResults);
+                // Ranking runs before the cut to maxResults: discarding afterwards
+                // would hand back fewer results than were asked for.
+                results = applyRankingRules(
+                  processWebSearchResults(result.results as any, itemIndex, result),
+                  rulesFromOptions(options.rankingRules),
+                ).slice(0, maxResults);
 
                 // Optional, opt-in: enrich the top-N results with extracted page text.
                 // Makes extra HTTP requests to the result sites (not DuckDuckGo),
@@ -1757,6 +1775,7 @@ export class DuckDuckGo implements INodeType {
           // Get news search specific parameters
           const newsQuery = this.getNodeParameter('newsQuery', itemIndex) as string;
           const newsSearchOptions = this.getNodeParameter('newsSearchOptions', itemIndex, {}) as {
+            rankingRules?: unknown;
             maxResults?: number;
             safeSearch?: number;
             region?: string;
@@ -1971,7 +1990,10 @@ export class DuckDuckGo implements INodeType {
               } else {
                 // Process and return the results
                 const maxResults = newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS;
-                results = processNewsSearchResults(result.results as any, itemIndex).slice(0, maxResults);
+                results = applyRankingRules(
+                  processNewsSearchResults(result.results as any, itemIndex),
+                  rulesFromOptions(newsSearchOptions.rankingRules),
+                ).slice(0, maxResults);
 
                 // Optional, opt-in: enrich the top-N results with extracted page text.
                 await enrichWithPageContent(results, newsSearchOptions, debugMode, operation);
@@ -2046,7 +2068,12 @@ export class DuckDuckGo implements INodeType {
                     isFallback: true,
                   }));
 
-                  results = processNewsSearchResults(newsResults, itemIndex).slice(0, newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS);
+                  // Rules apply to fallback results too: which site a result
+                  // came from does not depend on which path fetched it.
+                  results = applyRankingRules(
+                    processNewsSearchResults(newsResults, itemIndex),
+                    rulesFromOptions(newsSearchOptions.rankingRules),
+                  ).slice(0, newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS);
                   // Optional, opt-in: enrich fallback results too.
                   await enrichWithPageContent(results, newsSearchOptions, debugMode, operation);
                 }
@@ -2097,6 +2124,7 @@ export class DuckDuckGo implements INodeType {
           // Get video search specific parameters
           const videoQuery = this.getNodeParameter('videoQuery', itemIndex) as string;
           const videoSearchOptions = this.getNodeParameter('videoSearchOptions', itemIndex, {}) as {
+            rankingRules?: unknown;
             maxResults?: number;
             safeSearch?: number;
             region?: string;
@@ -2300,7 +2328,10 @@ export class DuckDuckGo implements INodeType {
               } else {
                 // Process and return the results
                 const maxResults = videoSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS;
-                results = processVideoSearchResults(result.results as any, itemIndex).slice(0, maxResults);
+                results = applyRankingRules(
+                  processVideoSearchResults(result.results as any, itemIndex),
+                  rulesFromOptions(videoSearchOptions.rankingRules),
+                ).slice(0, maxResults);
 
                 // Add cache information to the first result if in debug mode
                 if (debugMode && results.length > 0) {
@@ -2346,7 +2377,12 @@ export class DuckDuckGo implements INodeType {
                   isFallback: true,
                 }));
 
-                results = processVideoSearchResults(videoResults, itemIndex).slice(0, videoSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS);
+                // Rules apply to fallback results too: which site a result came
+                // from does not depend on which path fetched it.
+                results = applyRankingRules(
+                  processVideoSearchResults(videoResults, itemIndex),
+                  rulesFromOptions(videoSearchOptions.rankingRules),
+                ).slice(0, videoSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS);
 
                 // Leave fallback results populated; the error item below is only emitted if fallback produced no results.
               }

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -456,7 +456,6 @@ export class DuckDuckGo implements INodeType {
           },
         },
         options: [
-          rankingRulesProperty,
           {
             displayName: 'Maximum Results',
             name: 'maxResults',
@@ -468,6 +467,7 @@ export class DuckDuckGo implements INodeType {
               maxValue: 100,
             },
           },
+          rankingRulesProperty,
           {
             displayName: 'Region',
             name: 'region',
@@ -864,7 +864,6 @@ export class DuckDuckGo implements INodeType {
           },
         },
         options: [
-          rankingRulesProperty,
           {
             displayName: 'Maximum Results',
             name: 'maxResults',
@@ -876,6 +875,7 @@ export class DuckDuckGo implements INodeType {
               maxValue: 100,
             },
           },
+          rankingRulesProperty,
           {
             displayName: 'Region',
             name: 'region',
@@ -1060,7 +1060,6 @@ export class DuckDuckGo implements INodeType {
           },
         },
         options: [
-          rankingRulesProperty,
           {
             displayName: 'Maximum Results',
             name: 'maxResults',
@@ -1072,6 +1071,7 @@ export class DuckDuckGo implements INodeType {
               maxValue: 100,
             },
           },
+          rankingRulesProperty,
           {
             displayName: 'Region',
             name: 'region',

--- a/nodes/DuckDuckGo/__tests__/DuckDuckGo.test.ts
+++ b/nodes/DuckDuckGo/__tests__/DuckDuckGo.test.ts
@@ -158,6 +158,55 @@ describe('DuckDuckGo Node', () => {
   };
 
   describe('Web Search Operation', () => {
+    describe('ranking rules', () => {
+      it('discards, reorders and renumbers before the cut to maxResults', async () => {
+        // The whole point of doing this inside the node: discarding after the
+        // cut would hand back fewer results than were asked for. Four results
+        // in, one discarded, two asked for, two out.
+        setupNodeParameters('search', 'ranked query', {
+          maxResults: 2,
+          rankingRules: {
+            rule: [
+              { match: 'domain', value: 'spam.com', effect: 'discard' },
+              { match: 'domain', value: 'good.com', effect: 'boost' },
+            ],
+          },
+        });
+
+        (directSearch.directWebSearch as jest.Mock).mockResolvedValue({
+          results: [
+            { title: 'A', url: 'https://mid.com/a', description: 'a' },
+            { title: 'B', url: 'https://spam.com/b', description: 'b' },
+            { title: 'C', url: 'https://good.com/c', description: 'c' },
+            { title: 'D', url: 'https://other.com/d', description: 'd' },
+          ],
+        });
+
+        const output = (await duckDuckGoNode.execute.call(mockExecuteFunction)).flat();
+
+        expect(output.map((i) => i.json.url)).toEqual([
+          'https://good.com/c',
+          'https://mid.com/a',
+        ]);
+        expect(output.map((i) => i.json.position)).toEqual([1, 2]);
+      });
+
+      it('leaves the results alone when no rules are configured', async () => {
+        setupNodeParameters('search', 'plain query', { maxResults: 3 });
+
+        (directSearch.directWebSearch as jest.Mock).mockResolvedValue({
+          results: [
+            { title: 'A', url: 'https://a.com/1', description: 'a' },
+            { title: 'B', url: 'https://b.com/2', description: 'b' },
+          ],
+        });
+
+        const output = (await duckDuckGoNode.execute.call(mockExecuteFunction)).flat();
+
+        expect(output.map((i) => i.json.url)).toEqual(['https://a.com/1', 'https://b.com/2']);
+      });
+    });
+
     const mockWebSearchResults = {
       results: [
         {

--- a/nodes/DuckDuckGo/__tests__/resultRanking.test.ts
+++ b/nodes/DuckDuckGo/__tests__/resultRanking.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for resultRanking.ts.
+ *
+ * Two things carry most of the risk: a rule discarding something it was never
+ * meant to match, and the order of unmatched results drifting. Most of these
+ * assert that nothing moved.
+ */
+
+import { INodeExecutionData } from 'n8n-workflow';
+
+import { applyRankingRules, rulesFromOptions, IRankingRule } from '../resultRanking';
+
+const result = (url: string, position?: number): INodeExecutionData => ({
+  json: { url, ...(position === undefined ? {} : { position }) },
+  pairedItem: { item: 0 },
+});
+
+const urls = (items: INodeExecutionData[]) => items.map((i) => i.json.url);
+
+const rule = (
+  value: string,
+  effect: IRankingRule['effect'],
+  match: IRankingRule['match'] = 'domain',
+): IRankingRule => ({ value, effect, match });
+
+describe('applyRankingRules', () => {
+  describe('does nothing without usable rules', () => {
+    const items = [result('https://a.com/1'), result('https://b.com/2')];
+
+    it.each([
+      ['undefined', undefined],
+      ['an empty list', []],
+      ['rules with blank values', [rule('', 'discard'), rule('   ', 'boost')]],
+    ])('returns the items untouched for %s', (_label, rules) => {
+      expect(applyRankingRules(items, rules as IRankingRule[])).toBe(items);
+    });
+
+    it('returns an empty list untouched', () => {
+      const empty: INodeExecutionData[] = [];
+      expect(applyRankingRules(empty, [rule('a.com', 'discard')])).toBe(empty);
+    });
+  });
+
+  describe('discard', () => {
+    it('removes matching results and keeps the rest in order', () => {
+      const items = [
+        result('https://good.com/1'),
+        result('https://spam.com/2'),
+        result('https://other.com/3'),
+      ];
+
+      expect(urls(applyRankingRules(items, [rule('spam.com', 'discard')]))).toEqual([
+        'https://good.com/1',
+        'https://other.com/3',
+      ]);
+    });
+
+    it('covers subdomains, because a domain means the site', () => {
+      const items = [result('https://www.spam.com/a'), result('https://in.spam.com/b')];
+      expect(applyRankingRules(items, [rule('spam.com', 'discard')])).toHaveLength(0);
+    });
+
+    it('does not match a domain that merely ends with the same letters', () => {
+      const items = [result('https://notspam.com/a'), result('https://spam.com.evil.net/b')];
+      expect(urls(applyRankingRules(items, [rule('spam.com', 'discard')]))).toEqual([
+        'https://notspam.com/a',
+        'https://spam.com.evil.net/b',
+      ]);
+    });
+
+    it.each([
+      ['a bare domain', 'spam.com'],
+      ['a leading dot', '.spam.com'],
+      ['a wildcard', '*.spam.com'],
+    ])('accepts %s as the same rule', (_label, value) => {
+      const items = [result('https://www.spam.com/a'), result('https://keep.com/b')];
+      expect(urls(applyRankingRules(items, [rule(value, 'discard')]))).toEqual([
+        'https://keep.com/b',
+      ]);
+    });
+  });
+
+  describe('ordering', () => {
+    it('moves boosted results up and downranked ones down', () => {
+      const items = [
+        result('https://mid.com/1'),
+        result('https://bad.com/2'),
+        result('https://good.com/3'),
+        result('https://other.com/4'),
+      ];
+
+      const out = applyRankingRules(items, [
+        rule('good.com', 'boost'),
+        rule('bad.com', 'downrank'),
+      ]);
+
+      expect(urls(out)).toEqual([
+        'https://good.com/3',
+        'https://mid.com/1',
+        'https://other.com/4',
+        'https://bad.com/2',
+      ]);
+    });
+
+    it('keeps the original relative order inside each bucket', () => {
+      const items = [
+        result('https://x.com/1'),
+        result('https://y.com/2'),
+        result('https://x.com/3'),
+        result('https://y.com/4'),
+      ];
+
+      const out = applyRankingRules(items, [rule('x.com', 'boost')]);
+
+      expect(urls(out)).toEqual([
+        'https://x.com/1',
+        'https://x.com/3',
+        'https://y.com/2',
+        'https://y.com/4',
+      ]);
+    });
+
+    it('leaves everything alone when a rule matches nothing', () => {
+      const items = [result('https://a.com/1'), result('https://b.com/2')];
+      expect(urls(applyRankingRules(items, [rule('nowhere.com', 'boost')]))).toEqual([
+        'https://a.com/1',
+        'https://b.com/2',
+      ]);
+    });
+  });
+
+  describe('rule precedence', () => {
+    it('lets an earlier specific rule win over a later broad one', () => {
+      // Keeping the documentation while dropping the rest of a site is the
+      // reason the first match wins rather than a fixed order between actions.
+      const items = [
+        result('https://docs.example.com/guide'),
+        result('https://blog.example.com/spam'),
+      ];
+
+      const out = applyRankingRules(items, [
+        rule('docs.example.com', 'boost'),
+        rule('example.com', 'discard'),
+      ]);
+
+      expect(urls(out)).toEqual(['https://docs.example.com/guide']);
+    });
+
+    it('applies only the first matching rule, whichever it is', () => {
+      const items = [result('https://a.com/1')];
+      const out = applyRankingRules(items, [rule('a.com', 'discard'), rule('a.com', 'boost')]);
+      expect(out).toHaveLength(0);
+    });
+  });
+
+  describe('URL matching', () => {
+    it('matches anywhere in the URL', () => {
+      const items = [result('https://a.com/amp/page'), result('https://a.com/real/page')];
+      expect(urls(applyRankingRules(items, [rule('/amp/', 'discard', 'urlContains')]))).toEqual([
+        'https://a.com/real/page',
+      ]);
+    });
+
+    it('ignores case', () => {
+      const items = [result('https://a.com/AMP/page')];
+      expect(applyRankingRules(items, [rule('/amp/', 'discard', 'urlContains')])).toHaveLength(0);
+    });
+  });
+
+  describe('results a rule cannot judge', () => {
+    it.each([
+      ['no url at all', { json: { title: 'x' } } as INodeExecutionData],
+      ['an empty url', result('')],
+      ['a url that does not parse', result('not a url')],
+    ])('keeps a result with %s rather than discarding it', (_label, item) => {
+      // Discarding something because its URL looked odd would lose data over a
+      // rule it never had a chance to match.
+      const out = applyRankingRules([item], [rule('anything.com', 'discard')]);
+      expect(out).toHaveLength(1);
+    });
+
+    it('still matches a urlContains rule against an unparseable url', () => {
+      const out = applyRankingRules(
+        [result('not a url but contains spam')],
+        [rule('spam', 'discard', 'urlContains')],
+      );
+      expect(out).toHaveLength(0);
+    });
+  });
+
+  describe('position', () => {
+    it('renumbers position to match the new order', () => {
+      const items = [result('https://a.com/1', 1), result('https://b.com/2', 2)];
+      const out = applyRankingRules(items, [rule('b.com', 'boost')]);
+
+      expect(out.map((i) => [i.json.url, i.json.position])).toEqual([
+        ['https://b.com/2', 1],
+        ['https://a.com/1', 2],
+      ]);
+    });
+
+    it('renumbers after a discard so the numbers have no gaps', () => {
+      const items = [
+        result('https://a.com/1', 1),
+        result('https://gone.com/2', 2),
+        result('https://c.com/3', 3),
+      ];
+      const out = applyRankingRules(items, [rule('gone.com', 'discard')]);
+      expect(out.map((i) => i.json.position)).toEqual([1, 2]);
+    });
+
+    it('leaves results without a position alone', () => {
+      const items = [result('https://a.com/1'), result('https://b.com/2')];
+      const out = applyRankingRules(items, [rule('b.com', 'boost')]);
+      expect(out.every((i) => i.json.position === undefined)).toBe(true);
+    });
+
+    it('does not modify the items it was given', () => {
+      const items = [result('https://a.com/1', 1), result('https://b.com/2', 2)];
+      applyRankingRules(items, [rule('b.com', 'boost')]);
+      expect(items.map((i) => i.json.position)).toEqual([1, 2]);
+    });
+  });
+});
+
+describe('rulesFromOptions', () => {
+  it('reads the rows out of the fixed collection shape n8n produces', () => {
+    expect(
+      rulesFromOptions({
+        rule: [
+          { match: 'domain', value: 'a.com', effect: 'discard' },
+          { match: 'urlContains', value: '/amp/', effect: 'downrank' },
+        ],
+      }),
+    ).toEqual([
+      { match: 'domain', value: 'a.com', effect: 'discard' },
+      { match: 'urlContains', value: '/amp/', effect: 'downrank' },
+    ]);
+  });
+
+  it.each([
+    ['undefined, as in a workflow saved before the option existed', undefined],
+    ['an empty collection', {}],
+    ['a collection with no rows', { rule: [] }],
+    ['something that is not a collection', 'nonsense'],
+    ['a collection whose rows are not an array', { rule: 'nonsense' }],
+  ])('yields no rules for %s', (_label, value) => {
+    expect(rulesFromOptions(value)).toEqual([]);
+  });
+
+  it.each([
+    ['an unknown effect', { match: 'domain', value: 'a.com', effect: 'delete' }],
+    ['an unknown match type', { match: 'title', value: 'a.com', effect: 'discard' }],
+    ['a missing value', { match: 'domain', effect: 'discard' }],
+    ['a non-string value', { match: 'domain', value: 42, effect: 'discard' }],
+  ])('drops a row with %s rather than guessing at it', (_label, row) => {
+    // A row this function cannot read is a row whose intent is unknown, and
+    // guessing wrong could discard results the user wanted.
+    expect(rulesFromOptions({ rule: [row] })).toEqual([]);
+  });
+
+  it('keeps the good rows when one row is unreadable', () => {
+    const rules = rulesFromOptions({
+      rule: [
+        { match: 'domain', value: 'a.com', effect: 'discard' },
+        { match: 'domain', value: 'b.com', effect: 'nonsense' },
+      ],
+    });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].value).toBe('a.com');
+  });
+});

--- a/nodes/DuckDuckGo/resultRanking.ts
+++ b/nodes/DuckDuckGo/resultRanking.ts
@@ -1,0 +1,245 @@
+/**
+ * Local re-ranking of results that have already been fetched.
+ *
+ * A search engine ranks for everybody. A workflow usually wants something
+ * narrower — only documentation sites, never content farms, this vendor's blog
+ * before the aggregators that copy it. Doing that afterwards in a Filter or Sort
+ * node means writing the same expression into every workflow and getting the
+ * result count wrong, because discarding after the node has already cut to
+ * `maxResults` leaves fewer results than were asked for.
+ *
+ * Everything here happens on results already in memory. No rule causes a
+ * request, contacts a service, or leaves the process — a rule is applied to the
+ * list the node just built, and nothing else.
+ *
+ * The ordering model is deliberately blunt: three buckets, not scores. Boosted
+ * results keep their order among themselves and move above everything else,
+ * downranked ones likewise below, and everything unmatched stays exactly where
+ * DuckDuckGo put it. Weights would invite tuning a number nobody can reason
+ * about, and a stable partition is something a user can predict from the rules
+ * alone.
+ */
+
+import { INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+/** What a rule does to the results it matches. */
+export type RankingEffect = 'boost' | 'downrank' | 'discard';
+
+/** What part of a result a rule is tested against. */
+export type RankingMatch = 'domain' | 'urlContains';
+
+export interface IRankingRule {
+  match: RankingMatch;
+  value: string;
+  effect: RankingEffect;
+}
+
+/**
+ * Does `hostname` belong to `domain`?
+ *
+ * A bare domain covers its subdomains, because a user writing `pinterest.com`
+ * means the site, not the one hostname — `www.pinterest.com` and
+ * `in.pinterest.com` are the same site to them. The boundary check on the
+ * character before the suffix is what stops `notpinterest.com` matching.
+ */
+function hostMatchesDomain(hostname: string, domain: string): boolean {
+  const host = hostname.toLowerCase();
+  // Tolerate a leading "*." or "." so the three spellings a user might reach
+  // for all behave the same.
+  const suffix = domain.toLowerCase().replace(/^\*?\./, '');
+  if (!suffix) {
+    return false;
+  }
+  return host === suffix || host.endsWith(`.${suffix}`);
+}
+
+/** The URL a result carries, or an empty string when it has none. */
+function urlOf(item: INodeExecutionData): string {
+  const url = item.json?.url;
+  return typeof url === 'string' ? url : '';
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '';
+  }
+}
+
+function ruleMatches(rule: IRankingRule, url: string, hostname: string): boolean {
+  const value = rule.value?.trim();
+  if (!value) {
+    return false;
+  }
+  if (rule.match === 'domain') {
+    return hostname !== '' && hostMatchesDomain(hostname, value);
+  }
+  return url.toLowerCase().includes(value.toLowerCase());
+}
+
+/**
+ * Return the action for a result, or `undefined` when no rule applies.
+ *
+ * The first matching rule wins, so the order of the rules is the user's to
+ * decide: a boost for `docs.example.com` written above a discard for
+ * `example.com` keeps the documentation and drops the rest, which is a thing
+ * people actually want and which any fixed precedence between actions would
+ * make impossible.
+ */
+function effectFor(rules: IRankingRule[], item: INodeExecutionData): RankingEffect | undefined {
+  const url = urlOf(item);
+  if (!url) {
+    // A result with no URL cannot match anything, and must never be discarded
+    // by a rule it had no chance of matching.
+    return undefined;
+  }
+  const hostname = hostnameOf(url);
+  return rules.find((rule) => ruleMatches(rule, url, hostname))?.effect;
+}
+
+/**
+ * Apply ranking rules to processed results.
+ *
+ * Returns a new array; the input is not modified. With no usable rules the
+ * items are returned as they arrived, so the feature costs nothing when it is
+ * not configured.
+ *
+ * `position` is renumbered when present, because a result labelled 1 sitting
+ * third in the list is worse than no label at all.
+ */
+export function applyRankingRules(
+  items: INodeExecutionData[],
+  rules: IRankingRule[] | undefined,
+): INodeExecutionData[] {
+  const usable = (rules ?? []).filter((rule) => rule?.value?.trim());
+  if (usable.length === 0 || items.length === 0) {
+    return items;
+  }
+
+  const boosted: INodeExecutionData[] = [];
+  const normal: INodeExecutionData[] = [];
+  const downranked: INodeExecutionData[] = [];
+
+  for (const item of items) {
+    switch (effectFor(usable, item)) {
+      case 'discard':
+        break;
+      case 'boost':
+        boosted.push(item);
+        break;
+      case 'downrank':
+        downranked.push(item);
+        break;
+      default:
+        normal.push(item);
+    }
+  }
+
+  const ranked = [...boosted, ...normal, ...downranked];
+
+  return ranked.map((item, index) =>
+    typeof item.json?.position === 'number'
+      ? { ...item, json: { ...item.json, position: index + 1 } }
+      : item,
+  );
+}
+
+/**
+ * The rules as they arrive from the node parameter.
+ *
+ * n8n wraps a fixed collection as `{ rule: [...] }`, and a workflow saved
+ * before this option existed has no value at all, so the shape is checked
+ * rather than assumed. Anything unrecognised yields no rules, which leaves the
+ * results exactly as DuckDuckGo ordered them.
+ */
+export function rulesFromOptions(value: unknown): IRankingRule[] {
+  const rules = (value as { rule?: unknown } | undefined)?.rule;
+  if (!Array.isArray(rules)) {
+    return [];
+  }
+  return rules.filter(
+    (rule): rule is IRankingRule =>
+      typeof rule?.value === 'string' &&
+      (rule.effect === 'boost' || rule.effect === 'downrank' || rule.effect === 'discard') &&
+      (rule.match === 'domain' || rule.match === 'urlContains'),
+  );
+}
+
+/**
+ * The "Ranking Rules" option, shared by every operation that returns ranked
+ * results so the three cannot drift apart.
+ */
+export const rankingRulesProperty: INodeProperties = {
+  displayName: 'Ranking Rules',
+  name: 'rankingRules',
+  type: 'fixedCollection',
+  typeOptions: {
+    multipleValues: true,
+    sortable: true,
+  },
+  default: {},
+  placeholder: 'Add Rule',
+  description:
+    'Reorder or drop results by where they come from, applied locally to the results already fetched — no extra requests. Rules are checked in order and the first match wins, so put specific rules above broad ones. Applied before Maximum Results, so discarding still returns the number you asked for.',
+  options: [
+    {
+      displayName: 'Rule',
+      name: 'rule',
+      values: [
+        {
+          displayName: 'Match',
+          name: 'match',
+          type: 'options',
+          options: [
+            {
+              name: 'Domain',
+              value: 'domain',
+              description: 'The result\'s site, subdomains included',
+            },
+            {
+              name: 'URL Contains',
+              value: 'urlContains',
+              description: 'Any text anywhere in the result URL',
+            },
+          ],
+          default: 'domain',
+          description: 'What part of the result to test',
+        },
+        {
+          displayName: 'Value',
+          name: 'value',
+          type: 'string',
+          default: '',
+          placeholder: 'example.com',
+          description:
+            'Domain to match, subdomains included — "example.com" also matches "www.example.com". For URL Contains, any substring such as "/amp/".',
+        },
+        {
+          displayName: 'Effect',
+          name: 'effect',
+          type: 'options',
+          options: [
+            {
+              name: 'Boost',
+              value: 'boost',
+              description: 'Move matching results above the others',
+            },
+            {
+              name: 'Discard',
+              value: 'discard',
+              description: 'Remove matching results entirely',
+            },
+            {
+              name: 'Downrank',
+              value: 'downrank',
+              description: 'Move matching results below the others',
+            },
+          ],
+          default: 'discard',
+          description: 'What to do with a result this rule matches',
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Backlog P2-2. A search engine ranks for everybody; a workflow usually wants something narrower — only documentation sites, never the content farms that copy them, this vendor's own pages before the aggregators.

**Ranking Rules** does that locally, on results the node has already fetched. Available on Web, News and Video Search. Each rule matches a **Domain** (subdomains included) or a **URL Contains** substring, and **Boosts**, **Downranks** or **Discards** what it matches.

Nothing here contacts anything: no rule causes a request, no service is involved, no new dependency, and nothing leaves the process.

## The decisions worth arguing about

- **First match wins, rules ordered by the user.** A boost on `docs.example.com` above a discard on `example.com` keeps the documentation and drops the rest of the site. No fixed precedence between effects can express that, so the order is the user's to decide and the UI is sortable.
- **Three stable buckets, not scores.** Boosted results keep their order among themselves and move above everything else, downranked ones likewise below, and anything unmatched stays exactly where DuckDuckGo put it. A weight would be a number nobody can reason about; a partition is something you can predict from the rules alone.
- **A bare domain covers its subdomains.** Someone writing `pinterest.com` means the site. The boundary check is what stops `notpinterest.com` matching — there is a test for exactly that.
- **A result the rules cannot judge is kept.** No URL, or a URL that does not parse, is never discarded by a rule it had no chance to match. Losing data to a rule that never matched would be the worse failure.
- **`position` is renumbered**, because a result labelled 1 sitting third is worse than no label.

## Ranking has to run before the result limit — which turned out to be two places

The point of doing this in the node rather than a Filter node afterwards is that discarding after the cut to `maxResults` returns fewer results than were asked for. Ask for 10, discard a domain, get 7.

Wiring it before the final slice was not enough. **The direct web search path cuts the raw list to `maxResults` before results are even processed**, so a result promoted by a boost, or needed to backfill a discard, was already gone. The node-level test caught it. That early cut is now skipped when rules are configured, and the cut after ranking does the work — behaviour is unchanged for anyone not using the feature.

The same reasoning put ranking on the **News and Video fallback paths** as well: which site a result came from does not depend on which path fetched it.

## Verified

- **466 tests / 20 suites** pass; `tsc` clean; lint clean; `build:prod` + `verify-build` pass.
- 36 new tests for the module, most asserting nothing moved: unmatched order preserved, near-miss domains not matched, unjudgeable results kept, input array not mutated, and every unreadable rule shape yielding no rules rather than a guess.
- Two node-level tests prove the option actually reaches the ranking: four results in, one discarded, one boosted, `maxResults: 2` → the boosted result and the next survivor, renumbered 1 and 2. Plus one asserting results are untouched with no rules configured.

The parameter is named `effect` rather than `action` because `eslint-plugin-n8n-nodes-base` treats any options parameter called `action` as the node's operation selector and demands operation metadata for it. Renaming avoids a false positive rather than adding meaningless fields.

README gains a "Ranking Rules" section with a worked example; CHANGELOG has an Unreleased entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
