### PR TITLE
chore(ci): add timeouts, a package-contents gate, and a run summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    # A run takes under a minute. Without a limit a hung step would sit on a
+    # runner for the six-hour default before anyone found out.
+    timeout-minutes: 15
 
     steps:
       # Checkout the repository code
@@ -29,14 +32,18 @@ jobs:
 
       # Install dependencies
       - name: Install dependencies
+        # The only step that depends on a network it does not control.
+        timeout-minutes: 5
         run: npm ci
 
       # Run ESLint
       - name: Lint code
+        timeout-minutes: 3
         run: npm run lint
 
       # Build the project
       - name: Build
+        timeout-minutes: 5
         run: npm run build
 
       # Verify the build output
@@ -45,8 +52,47 @@ jobs:
 
       # Run tests (if available)
       - name: Run tests
-        run: npm run test:coverage
+        timeout-minutes: 10
+        run: npm run test:coverage -- --json --outputFile=jest-results.json
 
+      # Report what actually ran. A count in a README drifts silently; a count
+      # written by the run that produced it cannot.
+      - name: Summarise the test run
+        if: always()
+        run: |
+          {
+            echo "### Tests"
+            echo
+            if [ -f jest-results.json ]; then
+              node -e '
+                const r = require("./jest-results.json");
+                console.log("**" + r.numPassedTests + " of " + r.numTotalTests + " tests** passed across **" +
+                  r.numTotalTestSuites + " suites**" + (r.numFailedTests ? " — " + r.numFailedTests + " failed" : "") + ".");
+              '
+            else
+              echo "_The test run produced no results file._"
+            fi
+            echo
+            if [ -f coverage/coverage-summary.json ]; then
+              node -e '
+                const total = require("./coverage/coverage-summary.json").total;
+                console.log("| Metric | Coverage |");
+                console.log("|---|---|");
+                for (const k of ["statements", "branches", "functions", "lines"]) {
+                  console.log("| " + k + " | " + total[k].pct + "% (" + total[k].covered + "/" + total[k].total + ") |");
+                }
+              '
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
-  # Release job removed. npm publish is performed manually.
-  # GitHub Releases are created automatically by release.yml on v* tag push.
+      # The package is what users install, and it has been wrong before: every
+      # release from v32.7.0 attached an archive carrying compiled tests. This
+      # fails the build rather than waiting for someone to compare by hand.
+      - name: Check what would be published
+        run: |
+          npm run build:prod
+          npm pack --dry-run --json | node scripts/check-package-contents.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # npm publish and the GitHub Release are both handled by release.yml on a v*
+  # tag push, publishing from CI with npm provenance. Nothing is published from
+  # a laptop; docs/RELEASING.md has the procedure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,7 @@ jobs:
       # release from v32.7.0 attached an archive carrying compiled tests. This
       # fails the build rather than waiting for someone to compare by hand.
       - name: Check what would be published
-        run: |
-          npm run build:prod
-          npm pack --dry-run --json | node scripts/check-package-contents.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+        run: npm run check-package | tee -a "$GITHUB_STEP_SUMMARY"
 
   # npm publish and the GitHub Release are both handled by release.yml on a v*
   # tag push, publishing from CI with npm provenance. Nothing is published from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,15 @@ jobs:
       - name: Build distribution
         run: npm run build:prod
 
+      # CI runs this on every push, but a tag can be pushed before CI finishes,
+      # or at a commit whose CI failed, and this workflow does not wait for it.
+      # An npm version cannot be taken back, so the gate is repeated here rather
+      # than trusted to have run somewhere else. The build above is fresh, so
+      # this packs it directly instead of going through `check-package`, which
+      # would rebuild.
+      - name: Check what would be published
+        run: npm pack --dry-run --json | node scripts/check-package-contents.mjs
+
       # No token: the trusted publisher registered on npm authenticates this
       # workflow over OIDC, using a short-lived credential nothing has to store
       # or rotate. The id-token permission above is what makes that possible.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ yarn.lock
 # Internal working plan — kept local, not published
 PROJECT_PLAN.md
 release-body.md
+
+# Test artefacts
+coverage/
+jest-results.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **CI now fails on a package that would ship the wrong files.** Every GitHub release from v32.7.0 attached an archive carrying compiled tests, and nothing noticed until the two were compared by hand. `npm run check-package` reads `npm pack --dry-run` and asserts that nothing outside `dist/` ships beyond the three files npm always includes, that no compiled test, source map or TypeScript file is present, and that the node entry point and icon are.
+- **CI now fails on a package that would ship the wrong files.** Every GitHub release from v32.7.0 attached an archive carrying compiled tests, and nothing noticed until the two were compared by hand. `npm run check-package` reads `npm pack --dry-run` and asserts that nothing outside `dist/` ships beyond the three files npm always includes, that no compiled test, source map or TypeScript file is present, and that the node entry point and icon are. The release workflow runs the same check after its production build and before publishing, because a tag can be pushed before CI finishes or at a commit whose CI failed, and an npm version cannot be taken back.
 - **CI reports what actually ran.** The test and suite counts and the coverage table are written to the run summary, so a claim about the suite can be checked against the run that produced it rather than a README that may have drifted.
 - **CI steps have timeouts.** There were none, so a hung step would have held a runner for the six-hour default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI now fails on a package that would ship the wrong files.** Every GitHub release from v32.7.0 attached an archive carrying compiled tests, and nothing noticed until the two were compared by hand. `npm run check-package` reads `npm pack --dry-run` and asserts that nothing outside `dist/` ships beyond the three files npm always includes, that no compiled test, source map or TypeScript file is present, and that the node entry point and icon are.
+- **CI reports what actually ran.** The test and suite counts and the coverage table are written to the run summary, so a claim about the suite can be checked against the run that produced it rather than a README that may have drifted.
+- **CI steps have timeouts.** There were none, so a hung step would have held a runner for the six-hour default.
+
 ---
 
 ## [32.14.0] - 2026-09-09

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -62,11 +62,13 @@ What that order buys, and what it refuses:
   `npm run build` produced a 44-file tarball carrying compiled tests and
   `tsbuildinfo`, against the 25 files npm actually publishes.
 
-  CI now checks this on every push rather than leaving it to be noticed:
-  `npm run check-package` asserts that nothing outside `dist/` ships except the
-  three files npm always includes, that no compiled test, source map or
-  TypeScript file is present, and that the node entry point and icon are. Run it
-  locally before a release if you have touched the build.
+  This is now checked rather than left to be noticed. `npm run check-package`
+  builds and then asserts that nothing outside `dist/` ships except the three
+  files npm always includes, that no compiled test, source map or TypeScript
+  file is present, and that the node entry point and icon are. CI runs it on
+  every push, and **the release workflow runs it again after its own build and
+  before publishing** — a tag can be pushed before CI finishes, or at a commit
+  whose CI failed, and an npm version cannot be taken back.
 - **Publishing is skipped when the version already exists on npm**, so a rerun
   after a failure later in the job can still reach the release step. npm refuses
   to republish a version, which would otherwise make every rerun fail.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -61,6 +61,12 @@ What that order buys, and what it refuses:
   release is the same set of files that was published. Packing after a plain
   `npm run build` produced a 44-file tarball carrying compiled tests and
   `tsbuildinfo`, against the 25 files npm actually publishes.
+
+  CI now checks this on every push rather than leaving it to be noticed:
+  `npm run check-package` asserts that nothing outside `dist/` ships except the
+  three files npm always includes, that no compiled test, source map or
+  TypeScript file is present, and that the node entry point and icon are. Run it
+  locally before a release if you have touched the build.
 - **Publishing is skipped when the version already exists on npm**, so a rerun
   after a failure later in the job can still reach the release step. npm refuses
   to republish a version, which would otherwise make every rerun fail.

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.ts'],
   collectCoverageFrom: ['nodes/**/*.ts'],
+  // json-summary is not on by default; CI reads it to put the numbers in
+  // the run summary, so a claim about coverage can be checked against a run.
+  coverageReporters: ['text', 'lcov', 'json-summary'],
   coverageThreshold: {
     global: {
       branches: 30,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "tsc && gulp build:icons",
     "build:prod": "rimraf dist && npm run build && npm run clean-build",
     "clean-build": "node -e \"const fs=require('fs'); const path=require('path'); const glob=require('glob'); const files=glob.sync('dist/**/*.{tsbuildinfo,map}'); files.forEach(f => fs.existsSync(f) && fs.unlinkSync(f)); const toRemove=['dist/tests','dist/credentials'].concat(glob.sync('dist/**/__tests__',{onlyDirectories:true})); toRemove.forEach(d=>{if(fs.existsSync(d))fs.rmSync(d,{recursive:true});});\"",
+    "check-package": "npm pack --dry-run --json | node scripts/check-package-contents.mjs",
     "verify-build": "node -e \"const fs=require('fs'); const path=require('path'); const assert=require('assert'); assert.ok(fs.existsSync(path.join(__dirname, 'dist/nodes/DuckDuckGo/DuckDuckGo.node.js')), 'Main node file missing'); assert.ok(fs.existsSync(path.join(__dirname, 'dist/nodes/DuckDuckGo/duckduckgo.svg')), 'Icon missing'); console.log('✅ Build verification successful')\"",
     "dev": "tsc --watch",
     "format": "prettier nodes --write",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "tsc && gulp build:icons",
     "build:prod": "rimraf dist && npm run build && npm run clean-build",
     "clean-build": "node -e \"const fs=require('fs'); const path=require('path'); const glob=require('glob'); const files=glob.sync('dist/**/*.{tsbuildinfo,map}'); files.forEach(f => fs.existsSync(f) && fs.unlinkSync(f)); const toRemove=['dist/tests','dist/credentials'].concat(glob.sync('dist/**/__tests__',{onlyDirectories:true})); toRemove.forEach(d=>{if(fs.existsSync(d))fs.rmSync(d,{recursive:true});});\"",
-    "check-package": "npm pack --dry-run --json | node scripts/check-package-contents.mjs",
+    "check-package": "npm run build:prod && npm pack --dry-run --json | node scripts/check-package-contents.mjs",
     "verify-build": "node -e \"const fs=require('fs'); const path=require('path'); const assert=require('assert'); assert.ok(fs.existsSync(path.join(__dirname, 'dist/nodes/DuckDuckGo/DuckDuckGo.node.js')), 'Main node file missing'); assert.ok(fs.existsSync(path.join(__dirname, 'dist/nodes/DuckDuckGo/duckduckgo.svg')), 'Icon missing'); console.log('✅ Build verification successful')\"",
     "dev": "tsc --watch",
     "format": "prettier nodes --write",

--- a/scripts/check-package-contents.mjs
+++ b/scripts/check-package-contents.mjs
@@ -1,0 +1,94 @@
+/**
+ * Assert that the published tarball contains what it should and nothing else.
+ *
+ * Written after two releases went out wrong. Every GitHub release from v32.7.0
+ * attached a 44-file archive carrying compiled tests and `tsbuildinfo` against
+ * the 25 files npm received, and nothing noticed until someone compared them by
+ * hand. `files: ["dist"]` in package.json is the intent; this is the check that
+ * the intent held.
+ *
+ * Reads `npm pack --dry-run --json` on stdin, so it inspects what npm would
+ * actually send rather than what happens to be on disk:
+ *
+ *     npm pack --dry-run --json | node scripts/check-package-contents.mjs
+ *
+ * Taking the JSON rather than running npm itself keeps this a pure function of
+ * its input — no child process, nothing platform-specific, and the same command
+ * works locally and in CI.
+ *
+ * The `.mjs` extension is deliberate. `@n8n/scan-community-package` lints
+ * `**\/*.js`, `**\/*.ts` and `**\/*.json` across the whole repository, and build
+ * tooling that legitimately uses `process` and `console` would fail rules meant
+ * for node runtime code. This file is neither shipped nor loaded by the node.
+ */
+
+/** Files allowed outside `dist/`. npm always includes these three. */
+const ALLOWED_ROOT_FILES = new Set(['package.json', 'README.md', 'LICENSE.md']);
+
+/** Patterns that must never reach the published package. */
+const FORBIDDEN = [
+  { test: (p) => p.includes('__tests__'), why: 'compiled tests' },
+  { test: (p) => p.endsWith('.test.js'), why: 'compiled tests' },
+  { test: (p) => p.endsWith('.ts'), why: 'TypeScript source' },
+  { test: (p) => p.endsWith('.map'), why: 'source maps' },
+  { test: (p) => p.endsWith('.tsbuildinfo'), why: 'TypeScript build metadata' },
+  { test: (p) => p.startsWith('nodes/'), why: 'unbuilt source tree' },
+  { test: (p) => p.startsWith('scripts/'), why: 'build tooling' },
+  { test: (p) => p.startsWith('docs/'), why: 'documentation' },
+];
+
+/** Files whose absence would ship a node that cannot load. */
+const REQUIRED = [
+  'dist/nodes/DuckDuckGo/DuckDuckGo.node.js',
+  'dist/nodes/DuckDuckGo/duckduckgo.svg',
+  'dist/nodes/index.js',
+];
+
+const readStdin = async () => {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+const raw = await readStdin();
+if (!raw.trim()) {
+  console.error('No input. Pipe `npm pack --dry-run --json` into this script.');
+  process.exit(1);
+}
+
+const [pack] = JSON.parse(raw);
+const paths = pack.files.map((file) => file.path);
+const problems = [];
+
+for (const path of paths) {
+  const forbidden = FORBIDDEN.find((rule) => rule.test(path));
+  if (forbidden) {
+    problems.push(`${path} — ${forbidden.why} must not be published`);
+    continue;
+  }
+  if (!path.startsWith('dist/') && !ALLOWED_ROOT_FILES.has(path)) {
+    problems.push(`${path} — unexpected file outside dist/`);
+  }
+}
+
+for (const required of REQUIRED) {
+  if (!paths.includes(required)) {
+    problems.push(`${required} — missing; the node would not load`);
+  }
+}
+
+const summary = `${pack.name}@${pack.version}: ${pack.entryCount} files, ${(
+  pack.unpackedSize / 1024
+).toFixed(0)} kB unpacked`;
+
+if (problems.length > 0) {
+  console.error(`Package contents check FAILED — ${summary}`);
+  for (const problem of problems) {
+    console.error(`  - ${problem}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Package contents OK — ${summary}`);


### PR DESCRIPTION
Backlog **P3-3** and **P3-4**.

### Timeouts

\`ci.yml\` had **no \`timeout-minutes\` anywhere**, so a hung step would have held a runner for the six-hour default. A run takes under a minute; the job gets 15, and the three steps that can plausibly hang — install, build, tests — get their own.

### A gate on what would be published

The package is what users install, and it has been wrong before: every GitHub release from v32.7.0 attached an archive carrying compiled tests and \`tsbuildinfo\` against the 25 files npm received, and nothing noticed until the two were compared by hand. Packing after \`build:prod\` fixed the cause in 32.12.2 — this is the check that it stays fixed.

\`scripts/check-package-contents.mjs\` reads \`npm pack --dry-run\` and asserts that nothing outside \`dist/\` ships beyond the three files npm always includes, that no compiled test, source map or TypeScript file is present, and that the node entry point and icon are. Also exposed as \`npm run check-package\`.

Two details worth flagging for review:

- **It takes the pack JSON on stdin rather than spawning npm.** Node 20+ refuses \`execFileSync\` on a \`.cmd\` (I hit the \`EINVAL\` writing it), and a pure function of its input is testable and platform-independent anyway.
- **The \`.mjs\` extension is deliberate.** \`@n8n/scan-community-package\` lints \`**/*.js\`, \`**/*.ts\` and \`**/*.json\` across the whole repository, and build tooling that legitimately uses \`process\` and \`console\` would fail rules meant for node runtime code. This file is neither shipped nor loaded by the node.

### A run summary

Test and suite counts plus the coverage table go to \`$GITHUB_STEP_SUMMARY\`, so a claim about the suite can be checked against the run that produced it rather than a README that may have drifted. This needed \`json-summary\` added to jest's \`coverageReporters\` — **it is not on by default, and without it the step would have reported nothing forever.** Caught by running the step rather than assuming.

### Also

The comment at the bottom of \`ci.yml\` claiming npm publish is manual is replaced. That stopped being true in 32.12.2.

### Verified

- The summary step was **executed against real jest and coverage output**, rendering `466 of 466 tests` across `20 suites` and the four-row coverage table.
- The contents check passes on the current package (28 files) and **fails as intended** when a compiled test is injected into the file list, and when the entry point is removed.
- 466 tests / 20 suites, lint clean, YAML parses, all 7 \`run\` blocks pass \`bash -n\`, no \`${{ }}\` inside any \`run\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)