### PR TITLE
chore: send debug output to the n8n logger, not the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI now fails on a package that would ship the wrong files.** Every GitHub release from v32.7.0 attached an archive carrying compiled tests, and nothing noticed until the two were compared by hand. `npm run check-package` reads `npm pack --dry-run` and asserts that nothing outside `dist/` ships beyond the three files npm always includes, that no compiled test, source map or TypeScript file is present, and that the node entry point and icon are. The release workflow runs the same check after its production build and before publishing, because a tag can be pushed before CI finishes or at a commit whose CI failed, and an npm version cannot be taken back.
 - **CI reports what actually ran.** The test and suite counts and the coverage table are written to the run summary, so a claim about the suite can be checked against the run that produced it rather than a README that may have drifted.
 - **CI steps have timeouts.** There were none, so a hung step would have held a runner for the six-hour default.
+- **Debug output goes to the n8n log instead of the server console.** Debug Mode used to print JSON lines to standard output, which put them in the host's log with no execution context attached, and n8n Cloud does not permit console output from a community node at all. The same entries now go through n8n's own logger: errors as errors, warnings as warnings, everything else as debug. Turning Debug Mode on and off behaves exactly as before.
+
+  Three diagnostics that were **not** gated by Debug Mode — a primary news search failing before a fallback, and either fallback failing after it — were deliberately always-on so the cause stays visible when the fallback succeeds and no error reaches the workflow. They still are, now as warnings on the n8n logger rather than console lines.
+
+  Console calls in the fallback and direct-search modules were removed outright rather than rerouted: each one duplicated a message the function was already returning or throwing, so nothing is lost.
+- **Timers use n8n's `sleep` helper.** `setTimeout` is unavailable to community nodes on n8n Cloud. Behaviour is unchanged.
+- **`inputs`/`outputs` use `NodeConnectionTypes.Main`** rather than the `'main'` string literal.
+- **`package.json` declares `peerDependencies: { "n8n-workflow": "*" }`** and no longer carries a `resolutions` field. The field was yarn-only boilerplate; npm never applied it, and the lockfile records no override from it.
+
+  Taken together these cut the violations reported by `@n8n/scan-community-package` against the published package from 57 to 10 — and all 10 that remain are the runtime dependencies, which is a separate piece of work.
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,12 @@ module.exports = [
 					// options are kept together) rather than alphabetically. Consistent
 					// with node-param-fixed-collection-type-unsorted-items being off above.
 					'n8n-nodes-base/node-param-collection-type-unsorted-items': 'off',
+					// These two want the string literals `['main']`, while
+					// @n8n/community-nodes/node-connection-type-literal wants
+					// `NodeConnectionTypes.Main`. n8n's own community-node scanner
+					// resolves the conflict by turning these off, so we match it.
+					'n8n-nodes-base/node-class-description-inputs-wrong-regular-node': 'off',
+					'n8n-nodes-base/node-class-description-outputs-wrong': 'off',
 				},
 			},
 		],

--- a/nodes/DuckDuckGo/DuckDuckGo.node.ts
+++ b/nodes/DuckDuckGo/DuckDuckGo.node.ts
@@ -7,7 +7,9 @@ import {
   INodeType,
   INodeTypeDescription,
   IDataObject,
+  NodeConnectionTypes,
   NodeOperationError,
+  sleep,
 } from 'n8n-workflow';
 
 // Import types from duck-duck-scrape for compatibility, but use fallback functions
@@ -47,6 +49,8 @@ import { DEFAULT_PARAMETERS, NODE_INFO, REGIONS, BROWSER_USER_AGENT } from './co
 import {
   parseApiError,
   createLogEntry,
+  makeDebugLogger,
+  DebugLogger,
   LogLevel,
 } from './utils';
 
@@ -63,11 +67,6 @@ import { fetchPageContent, fetchPageContents } from './pageContent';
 import { getInstantAnswer } from './instantAnswer';
 import { getAutocomplete } from './autocomplete';
 import { getCooldownReason } from './challengeCooldown';
-
-// Sleep for a fixed amount of time
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 
 /**
@@ -140,7 +139,7 @@ async function enrichWithPageContent(
     pageContentTimeout?: number;
     includePageMetadata?: boolean;
   },
-  debugMode: boolean,
+  debugLog: DebugLogger | undefined,
   operation: string,
 ): Promise<void> {
   if (!pageOpts.fetchPageContent || results.length === 0) {
@@ -180,14 +179,12 @@ async function enrichWithPageContent(
     }
   });
 
-  if (debugMode) {
-    console.log(JSON.stringify(createLogEntry(
+  debugLog?.(createLogEntry(
       LogLevel.INFO,
       `Fetched page content for ${count} of ${results.length} ${operation} results`,
       operation,
-      { count, pageContentOptions: pcOptions },
-    )));
-  }
+    { count, pageContentOptions: pcOptions },
+  ));
 }
 
 
@@ -206,8 +203,8 @@ export class DuckDuckGo implements INodeType {
     defaults: {
       name: NODE_INFO.DISPLAY_NAME,
     },
-    inputs: ['main'],
-    outputs: ['main'],
+    inputs: [NodeConnectionTypes.Main],
+    outputs: [NodeConnectionTypes.Main],
     // @ts-ignore - Enable this node to be used as an AI Agent tool
     usableAsTool: true,
     credentials: [],
@@ -1195,6 +1192,7 @@ export class DuckDuckGo implements INodeType {
     },
   ): Promise<Array<any>> {
     const debugMode = this.getNodeParameter('debugMode', 0, false) as boolean;
+    const debugLog = makeDebugLogger(this.logger, debugMode);
 
     // Use the enhanced VQD pagination with corrected SearchOptions
     const paginationResult = await paginateWithVqd(
@@ -1209,7 +1207,7 @@ export class DuckDuckGo implements INodeType {
         pageSize: DEFAULT_PAGINATION_CONFIG.pageSize,
         maxPages: Math.min(DEFAULT_PAGINATION_CONFIG.maxPages, Math.ceil(options.maxResults / DEFAULT_PAGINATION_CONFIG.pageSize)),
         delayBetweenRequests: DEFAULT_PAGINATION_CONFIG.delayBetweenRequests,
-        debugMode,
+        debugLog,
       }
     );
 
@@ -1265,7 +1263,7 @@ export class DuckDuckGo implements INodeType {
               'webSearchWithSuperPagination',
               { query, error: error.message }
             );
-            console.error(JSON.stringify(logEntry));
+            debugLog?.(logEntry);
           }
           break;
         }
@@ -1284,6 +1282,7 @@ export class DuckDuckGo implements INodeType {
     const items = this.getInputData();
     const returnData: INodeExecutionData[] = [];
     const debugMode = this.getNodeParameter('debugMode', 0, false) as boolean;
+    const debugLog = makeDebugLogger(this.logger, debugMode);
 
 
     // Get cache settings
@@ -1367,7 +1366,7 @@ export class DuckDuckGo implements INodeType {
               operation,
               { originalQuery: query, enhancedQuery, operators: options.searchOperators }
             );
-            console.log(JSON.stringify(logEntry));
+            debugLog?.(logEntry);
           }
 
           // Set up search options with correct API according to duck-duck-scrape documentation
@@ -1399,7 +1398,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: enhancedQuery, options: searchOptions, cacheKey }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               result = cachedResult;
@@ -1417,7 +1416,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: enhancedQuery, options: searchOptions, cacheEnabled: enableCache }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               // SIMPLIFIED: Execute search directly using our direct implementation
@@ -1465,7 +1464,7 @@ export class DuckDuckGo implements INodeType {
                     operation,
                     { query: enhancedQuery, options: searchOptions, cacheTTL, cacheKey }
                   );
-                  console.log(JSON.stringify(logEntry));
+                  debugLog?.(logEntry);
                 }
               }
             }
@@ -1479,7 +1478,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: enhancedQuery, options: searchOptions }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               results = [{
@@ -1522,7 +1521,7 @@ export class DuckDuckGo implements INodeType {
                 // Optional, opt-in: enrich the top-N results with extracted page text.
                 // Makes extra HTTP requests to the result sites (not DuckDuckGo),
                 // so it only runs when the user enables "Fetch Page Content".
-                await enrichWithPageContent(results, options, debugMode, operation);
+                await enrichWithPageContent(results, options, debugLog, operation);
 
                 // Add cache information to the first result if in debug mode
                 if (debugMode && results.length > 0) {
@@ -1544,7 +1543,7 @@ export class DuckDuckGo implements INodeType {
                 { query: enhancedQuery, options: searchOptions },
                 error instanceof Error ? error : new Error(String(error))
               );
-              console.error(JSON.stringify(logEntry));
+              debugLog?.(logEntry);
             }
 
             results = [{
@@ -1603,7 +1602,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: imageQuery, options: searchOptions, cacheKey }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               result = cachedResult;
@@ -1621,7 +1620,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: imageQuery, options: searchOptions, cacheEnabled: enableCache }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               // Image search costs a page GET purely to obtain a VQD, then the
@@ -1682,7 +1681,7 @@ export class DuckDuckGo implements INodeType {
                     operation,
                     { query: imageQuery, options: searchOptions, cacheTTL, cacheKey }
                   );
-                  console.log(JSON.stringify(logEntry));
+                  debugLog?.(logEntry);
                 }
               }
             }
@@ -1696,7 +1695,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: imageQuery, options: searchOptions }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               results = [{
@@ -1751,7 +1750,7 @@ export class DuckDuckGo implements INodeType {
                 { query: imageQuery, options: searchOptions },
                 error instanceof Error ? error : new Error(String(error))
               );
-              console.error(JSON.stringify(logEntry));
+              debugLog?.(logEntry);
             }
 
             results = [{
@@ -1826,7 +1825,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: newsQuery, options: searchOptions, cacheKey }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               result = cachedResult;
@@ -1844,7 +1843,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: newsQuery, options: searchOptions, cacheEnabled: enableCache }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               // The back-off must gate the primary call too, not just the
@@ -1882,7 +1881,7 @@ export class DuckDuckGo implements INodeType {
                       operation,
                       { query: newsQuery, options: searchOptions, page }
                     );
-                    console.log(JSON.stringify(logEntry));
+                    debugLog?.(logEntry);
                   }
 
                   try {
@@ -1919,7 +1918,7 @@ export class DuckDuckGo implements INodeType {
                         operation,
                         { query: newsQuery, options: searchOptions, page }
                       );
-                      console.error(JSON.stringify(logEntry));
+                      debugLog?.(logEntry);
                     }
                     break;
                   }
@@ -1943,7 +1942,7 @@ export class DuckDuckGo implements INodeType {
                     operation,
                     { query: newsQuery, options: searchOptions, cacheTTL, cacheKey }
                   );
-                  console.log(JSON.stringify(logEntry));
+                  debugLog?.(logEntry);
                 }
               }
             }
@@ -1957,7 +1956,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: newsQuery, options: searchOptions }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               results = [{
@@ -1996,7 +1995,7 @@ export class DuckDuckGo implements INodeType {
                 ).slice(0, maxResults);
 
                 // Optional, opt-in: enrich the top-N results with extracted page text.
-                await enrichWithPageContent(results, newsSearchOptions, debugMode, operation);
+                await enrichWithPageContent(results, newsSearchOptions, debugLog, operation);
 
                 // Add cache information to the first result if in debug mode
                 if (debugMode && results.length > 0) {
@@ -2007,10 +2006,13 @@ export class DuckDuckGo implements INodeType {
             }
           } catch (error) {
             // Log the primary failure reason before attempting fallback.
-            // Always emitted (not gated by debugMode) so the cause is visible
-            // in the n8n server log even when fallback succeeds and no error
-            // item is returned to the workflow.
-            console.warn(`[DuckDuckGo] Primary news search failed (query: "${newsQuery}"): ${(error instanceof Error ? error.message : String(error))}`);
+            // Always emitted (not gated by Debug Mode) so the cause is visible
+            // in the n8n log even when fallback succeeds and no error item is
+            // returned to the workflow.
+            this.logger.warn(
+              `Primary news search failed: ${error instanceof Error ? error.message : String(error)}`,
+              { query: newsQuery },
+            );
 
             // Try fallback search if duck-duck-scrape fails
             try {
@@ -2075,13 +2077,15 @@ export class DuckDuckGo implements INodeType {
                     rulesFromOptions(newsSearchOptions.rankingRules),
                   ).slice(0, newsSearchOptions.maxResults ?? DEFAULT_PARAMETERS.MAX_RESULTS);
                   // Optional, opt-in: enrich fallback results too.
-                  await enrichWithPageContent(results, newsSearchOptions, debugMode, operation);
+                  await enrichWithPageContent(results, newsSearchOptions, debugLog, operation);
                 }
                 // If relevantResults is empty, fall through to the error-item path below
                 // so the caller gets a meaningful signal instead of silence.
               }
             } catch (fallbackError) {
-              console.error('Fallback news search also failed:', fallbackError);
+              this.logger.warn(
+                `Fallback news search also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
+              );
             }
 
             // Only emit the error item when the fallback also produced nothing
@@ -2099,7 +2103,7 @@ export class DuckDuckGo implements INodeType {
                   { query: newsQuery, options: searchOptions },
                   error instanceof Error ? error : new Error(String(error))
                 );
-                console.error(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               results = [{
@@ -2163,7 +2167,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: videoQuery, options: searchOptions, cacheKey }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               result = cachedResult;
@@ -2185,7 +2189,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: videoQuery, options: searchOptions, cacheEnabled: enableCache }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               const videoCooling = getCooldownReason();
@@ -2220,7 +2224,7 @@ export class DuckDuckGo implements INodeType {
                       operation,
                       { query: videoQuery, options: searchOptions, page }
                     );
-                    console.log(JSON.stringify(logEntry));
+                    debugLog?.(logEntry);
                   }
 
                   try {
@@ -2257,7 +2261,7 @@ export class DuckDuckGo implements INodeType {
                         operation,
                         { query: videoQuery, options: searchOptions, page }
                       );
-                      console.error(JSON.stringify(logEntry));
+                      debugLog?.(logEntry);
                     }
                     break;
                   }
@@ -2281,7 +2285,7 @@ export class DuckDuckGo implements INodeType {
                     operation,
                     { query: videoQuery, options: searchOptions, cacheTTL, cacheKey }
                   );
-                  console.log(JSON.stringify(logEntry));
+                  debugLog?.(logEntry);
                 }
               }
             }
@@ -2295,7 +2299,7 @@ export class DuckDuckGo implements INodeType {
                   operation,
                   { query: videoQuery, options: searchOptions }
                 );
-                console.log(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               results = [{
@@ -2387,7 +2391,9 @@ export class DuckDuckGo implements INodeType {
                 // Leave fallback results populated; the error item below is only emitted if fallback produced no results.
               }
             } catch (fallbackError) {
-              console.error('Fallback video search also failed:', fallbackError);
+              this.logger.warn(
+                `Fallback video search also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
+              );
             }
 
             // Only emit the error item when the fallback also produced nothing
@@ -2405,7 +2411,7 @@ export class DuckDuckGo implements INodeType {
                   { query: videoQuery, options: searchOptions },
                   error instanceof Error ? error : new Error(String(error))
                 );
-                console.error(JSON.stringify(logEntry));
+                debugLog?.(logEntry);
               }
 
               results = [{
@@ -2578,7 +2584,7 @@ export class DuckDuckGo implements INodeType {
               {},
               error instanceof Error ? error : new Error(String(error))
             );
-            console.error(JSON.stringify(logEntry));
+            debugLog?.(logEntry);
           }
 
           returnData.push({
@@ -2607,7 +2613,7 @@ export class DuckDuckGo implements INodeType {
             {},
             error instanceof Error ? error : new Error(String(error))
           );
-          console.error(JSON.stringify(logEntry));
+          debugLog?.(logEntry);
         }
 
 

--- a/nodes/DuckDuckGo/__tests__/debugLogger.test.ts
+++ b/nodes/DuckDuckGo/__tests__/debugLogger.test.ts
@@ -1,0 +1,54 @@
+import type { Logger } from 'n8n-workflow';
+import { createLogEntry, makeDebugLogger, LogLevel } from '../utils';
+
+type MockLogger = Record<'debug' | 'info' | 'warn' | 'error', jest.Mock>;
+
+const makeLogger = (): MockLogger => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+const asLogger = (l: MockLogger) => l as unknown as Logger;
+
+describe('makeDebugLogger', () => {
+  it('returns nothing when Debug Mode is off, so call sites emit nothing', () => {
+    expect(makeDebugLogger(asLogger(makeLogger()), false)).toBeUndefined();
+  });
+
+  it('routes each level to the matching logger method', () => {
+    const logger = makeLogger();
+    const debugLog = makeDebugLogger(asLogger(logger), true)!;
+
+    debugLog(createLogEntry(LogLevel.ERROR, 'boom', 'search'));
+    debugLog(createLogEntry(LogLevel.WARN, 'careful', 'search'));
+    debugLog(createLogEntry(LogLevel.INFO, 'fyi', 'search'));
+    debugLog(createLogEntry(LogLevel.DEBUG, 'detail', 'search'));
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    // INFO and DEBUG both land on debug: an entry only exists because the user
+    // asked for debugging, so it should not show up at the instance's info level.
+    expect(logger.debug).toHaveBeenCalledTimes(2);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('passes the message separately and the rest as metadata', () => {
+    const logger = makeLogger();
+    const debugLog = makeDebugLogger(asLogger(logger), true)!;
+
+    debugLog(createLogEntry(LogLevel.ERROR, 'request failed', 'webSearch', { query: 'cats' }));
+
+    const [message, metadata] = logger.error.mock.calls[0];
+    expect(message).toBe('request failed');
+    expect(metadata).toMatchObject({
+      level: LogLevel.ERROR,
+      operation: 'webSearch',
+      data: { query: 'cats' },
+    });
+    // The message must not be duplicated into the metadata bag.
+    expect(metadata).not.toHaveProperty('message');
+    expect(typeof metadata.timestamp).toBe('string');
+  });
+});

--- a/nodes/DuckDuckGo/__tests__/vqdPagination.test.ts
+++ b/nodes/DuckDuckGo/__tests__/vqdPagination.test.ts
@@ -54,7 +54,6 @@ describe('VQD Pagination', () => {
         pageSize: 10,
         maxPages: 3,
         delayBetweenRequests: 10,
-        debugMode: false,
       };
 
       const result = await paginateWithVqd('test query', {}, options);
@@ -88,7 +87,6 @@ describe('VQD Pagination', () => {
         pageSize: 10,
         maxPages: 3,
         delayBetweenRequests: 10, // Short delay for tests
-        debugMode: false,
       };
 
       const result = await paginateWithVqd('test query', {}, options);
@@ -131,7 +129,6 @@ describe('VQD Pagination', () => {
         pageSize: 10,
         maxPages: 5,
         delayBetweenRequests: 10,
-        debugMode: false,
       };
 
       const result = await paginateWithVqd('test query', {}, options);

--- a/nodes/DuckDuckGo/directSearch.ts
+++ b/nodes/DuckDuckGo/directSearch.ts
@@ -195,8 +195,6 @@ export async function directWebSearch(query: string, options: {
 
     return { results };
   } catch (error) {
-    console.error('Direct web search error:', error.message);
-
     // Re-throw errors that already carry specific, user-readable messages
     // (e.g. the parser-failure error thrown above — no .code, no .response)
     if (!error.code && !error.response) {
@@ -368,8 +366,6 @@ export async function directImageSearch(query: string, options: {
 
     return { results, vqd };
   } catch (error) {
-    console.error('Direct image search error:', error.message);
-
     // Preserve typed errors (e.g. the bot-challenge error) rather than
     // flattening them into a generic message and losing their guidance.
     if (error instanceof DuckDuckGoError) {

--- a/nodes/DuckDuckGo/fallbackSearch.ts
+++ b/nodes/DuckDuckGo/fallbackSearch.ts
@@ -204,7 +204,6 @@ export async function fallbackWebSearch(
     };
 
   } catch (error) {
-    console.error('Fallback search error:', error);
     return {
       success: false,
       noResults: true,
@@ -229,7 +228,6 @@ export async function fallbackNewsSearch(
     return await fallbackWebSearch(newsQuery, options);
 
   } catch (error) {
-    console.error('Fallback news search error:', error);
     return {
       success: false,
       noResults: true,
@@ -252,7 +250,6 @@ export async function fallbackVideoSearch(
     return await fallbackWebSearch(videoQuery, options);
 
   } catch (error) {
-    console.error('Fallback video search error:', error);
     return {
       success: false,
       noResults: true,

--- a/nodes/DuckDuckGo/utils.ts
+++ b/nodes/DuckDuckGo/utils.ts
@@ -2,6 +2,8 @@
  * Utilities and helper functions for the DuckDuckGo node
  */
 
+import type { Logger, LogMetadata } from 'n8n-workflow';
+
 /**
  * HTML entity mapping for decoding
  */
@@ -113,6 +115,43 @@ export function createLogEntry(
   }
 
   return logEntry;
+}
+
+/**
+ * Sink for the node's debug entries.
+ *
+ * Present only while Debug Mode is on, so a call site can emit unconditionally
+ * with `debugLog?.(...)` rather than guarding on the flag itself.
+ */
+export type DebugLogger = (entry: ILogEntry) => void;
+
+/**
+ * Builds the debug sink for one execution.
+ *
+ * Entries go to n8n's own logger rather than to stdout: the instance log then
+ * carries them with the execution's context, a user who has not asked for
+ * debugging sees nothing, and n8n Cloud does not permit console output at all.
+ *
+ * @param logger - `this.logger` from the execution context
+ * @param enabled - the node's Debug Mode parameter
+ * @returns a sink, or undefined when debugging is off
+ */
+export function makeDebugLogger(logger: Logger, enabled: boolean): DebugLogger | undefined {
+  if (!enabled) return undefined;
+
+  return ({ message, ...meta }) => {
+    const metadata = meta as LogMetadata;
+    switch (meta.level) {
+      case LogLevel.ERROR:
+        logger.error(message, metadata);
+        break;
+      case LogLevel.WARN:
+        logger.warn(message, metadata);
+        break;
+      default:
+        logger.debug(message, metadata);
+    }
+  };
 }
 
 /**

--- a/nodes/DuckDuckGo/vqdPagination.ts
+++ b/nodes/DuckDuckGo/vqdPagination.ts
@@ -3,8 +3,9 @@
  * Provides improved pagination capabilities for DuckDuckGo searches with 2025 API compatibility
  */
 
+import { sleep } from 'n8n-workflow';
 import { search, SearchOptions } from 'duck-duck-scrape';
-import { createLogEntry, LogLevel } from './utils';
+import { createLogEntry, LogLevel, DebugLogger } from './utils';
 import { DuckDuckGoError, DuckDuckGoErrorType } from './errors';
 
 /**
@@ -26,7 +27,7 @@ export interface IPaginationOptions {
   pageSize: number;
   maxPages: number;
   delayBetweenRequests: number;
-  debugMode?: boolean;
+  debugLog?: DebugLogger;
   useBackupStrategy?: boolean;
 }
 
@@ -106,8 +107,7 @@ function updateVqdTokenCache(query: string, token: string | undefined, increment
  */
 async function sleepWithJitter(baseDelay: number): Promise<void> {
   const jitter = Math.random() * 0.5 * baseDelay;
-  const totalDelay = baseDelay + jitter;
-  return new Promise(resolve => setTimeout(resolve, totalDelay));
+  await sleep(baseDelay + jitter);
 }
 
 /**
@@ -131,14 +131,14 @@ export async function paginateWithVqd(
     pageSize,
     maxPages,
     delayBetweenRequests,
-    debugMode,
+    debugLog,
     useBackupStrategy = true
   } = paginationOptions;
 
   try {
     // First, try to get initial results and VQD token if not cached
     if (!vqdManager?.token) {
-      const initialResult = await getInitialResults(query, baseOptions, debugMode);
+      const initialResult = await getInitialResults(query, baseOptions, debugLog);
 
       if (initialResult.success && initialResult.data) {
         results.push(...initialResult.data.results);
@@ -171,7 +171,7 @@ export async function paginateWithVqd(
       // Strategy 1: Try with VQD token if available
       if (vqdManager?.token) {
         try {
-          pageResult = await getPageWithVqd(query, baseOptions, vqdManager, currentPage, pageSize, debugMode);
+          pageResult = await getPageWithVqd(query, baseOptions, vqdManager, currentPage, pageSize, debugLog);
           if (pageResult?.results?.length > 0) {
             results.push(...pageResult.results);
             pageSuccess = true;
@@ -188,14 +188,12 @@ export async function paginateWithVqd(
           }
         } catch (vqdError) {
           errors.push(`VQD pagination error on page ${currentPage + 1}: ${vqdError.message}`);
-      if (debugMode) {
-            console.error(JSON.stringify(createLogEntry(
-              LogLevel.ERROR,
-              `VQD pagination failed: ${vqdError.message}`,
-          'paginateWithVqd',
-              { query, page: currentPage + 1, error: vqdError.message }
-            )));
-          }
+          debugLog?.(createLogEntry(
+            LogLevel.ERROR,
+            `VQD pagination failed: ${vqdError.message}`,
+            'paginateWithVqd',
+            { query, page: currentPage + 1, error: vqdError.message }
+          ));
 
           // Invalidate the VQD token if it's clearly expired
           if (vqdError.message.includes('VQD') || vqdError.message.includes('token')) {
@@ -209,7 +207,7 @@ export async function paginateWithVqd(
       if (!pageSuccess && useBackupStrategy) {
         try {
           strategy = vqdManager ? 'hybrid' : 'fallback';
-          pageResult = await getFallbackResults(query, baseOptions, currentPage, pageSize, debugMode);
+          pageResult = await getFallbackResults(query, baseOptions, currentPage, pageSize, debugLog);
 
           if (pageResult?.results?.length > 0) {
         results.push(...pageResult.results);
@@ -218,14 +216,12 @@ export async function paginateWithVqd(
           }
         } catch (fallbackError) {
           errors.push(`Fallback strategy failed on page ${currentPage + 1}: ${fallbackError.message}`);
-          if (debugMode) {
-            console.error(JSON.stringify(createLogEntry(
-              LogLevel.ERROR,
-              `Fallback pagination failed: ${fallbackError.message}`,
-              'paginateWithVqd',
-              { query, page: currentPage + 1, error: fallbackError.message }
-            )));
-          }
+          debugLog?.(createLogEntry(
+            LogLevel.ERROR,
+            `Fallback pagination failed: ${fallbackError.message}`,
+            'paginateWithVqd',
+            { query, page: currentPage + 1, error: fallbackError.message }
+          ));
         }
       }
 
@@ -240,20 +236,18 @@ export async function paginateWithVqd(
         // Check if we should continue (less results than expected might mean end of results)
         const expectedMinResults = Math.min(pageSize * 0.5, 3); // At least 50% of page size or 3 results
         if (pageResult?.results?.length < expectedMinResults) {
-        hasMore = false;
-      if (debugMode) {
-            console.log(JSON.stringify(createLogEntry(
-              LogLevel.INFO,
-              `Received fewer results than expected, assuming end of results`,
-          'paginateWithVqd',
-          {
-            query,
-            page: currentPage + 1,
-                received: pageResult?.results?.length,
-                expected: pageSize
-          }
-        )));
-      }
+          hasMore = false;
+          debugLog?.(createLogEntry(
+            LogLevel.INFO,
+            'Received fewer results than expected, assuming end of results',
+            'paginateWithVqd',
+            {
+              query,
+              page: currentPage + 1,
+              received: pageResult?.results?.length,
+              expected: pageSize,
+            }
+          ));
         }
       }
 
@@ -292,17 +286,15 @@ export async function paginateWithVqd(
 async function getInitialResults(
   query: string,
   baseOptions: SearchOptions,
-  debugMode?: boolean
+  debugLog?: DebugLogger
 ): Promise<{ success: boolean; data?: any; error?: string }> {
   try {
-    if (debugMode) {
-      console.log(JSON.stringify(createLogEntry(
-        LogLevel.INFO,
-        `Fetching initial results for: ${query}`,
-        'getInitialResults',
-        { query, options: baseOptions }
-      )));
-    }
+    debugLog?.(createLogEntry(
+      LogLevel.INFO,
+      `Fetching initial results for: ${query}`,
+      'getInitialResults',
+      { query, options: baseOptions }
+    ));
 
     const result = await search(query, baseOptions);
 
@@ -325,7 +317,7 @@ async function getPageWithVqd(
   vqdManager: IVqdTokenManager,
   currentPage: number,
   pageSize: number,
-  debugMode?: boolean
+  debugLog?: DebugLogger
 ): Promise<any> {
   const offset = currentPage * pageSize;
 
@@ -335,20 +327,18 @@ async function getPageWithVqd(
     offset: offset,
   };
 
-  if (debugMode) {
-    console.log(JSON.stringify(createLogEntry(
-      LogLevel.INFO,
-      `Fetching page ${currentPage + 1} with VQD token`,
-      'getPageWithVqd',
-      {
-        query,
-        page: currentPage + 1,
-        offset,
-        vqdUsage: vqdManager.usageCount,
-        vqdToken: vqdManager.token ? vqdManager.token.substring(0, 10) + '...' : 'undefined'
-      }
-    )));
-  }
+  debugLog?.(createLogEntry(
+    LogLevel.INFO,
+    `Fetching page ${currentPage + 1} with VQD token`,
+    'getPageWithVqd',
+    {
+      query,
+      page: currentPage + 1,
+      offset,
+      vqdUsage: vqdManager.usageCount,
+      vqdToken: vqdManager.token ? vqdManager.token.substring(0, 10) + '...' : 'undefined'
+    }
+  ));
 
   return await search(query, paginationOptions);
 }
@@ -361,16 +351,14 @@ async function getFallbackResults(
   baseOptions: SearchOptions,
   currentPage: number,
   pageSize: number,
-  debugMode?: boolean
+  debugLog?: DebugLogger
 ): Promise<any> {
-  if (debugMode) {
-    console.log(JSON.stringify(createLogEntry(
-      LogLevel.INFO,
-      `Using fallback strategy for page ${currentPage + 1}`,
-      'getFallbackResults',
-      { query, page: currentPage + 1 }
-    )));
-  }
+  debugLog?.(createLogEntry(
+    LogLevel.INFO,
+    `Using fallback strategy for page ${currentPage + 1}`,
+    'getFallbackResults',
+    { query, page: currentPage + 1 }
+  ));
 
   // Try basic search without VQD for this page
   const basicOptions = { ...baseOptions };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "n8n-workflow": "*"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -81,13 +81,13 @@
     "duck-duck-scrape": "^2.2.7",
     "linkedom": "^0.18.0"
   },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  },
   "engines": {
     "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "resolutions": {
-    "@n8n/client-oauth2/axios": "^1.13.0"
   }
 }


### PR DESCRIPTION
## Why

Measured, not guessed. `@n8n/scan-community-package@0.35.0` against the published `32.14.0`:

| leg | before | after |
|---|---|---|
| published tarball | 57 errors | **10** |
| source checkout | 103 errors | **54** |

Every one of the 10 remaining on the tarball is `no-restricted-imports` / `no-runtime-dependencies` — the four runtime libraries. That is separate work, and it is now the *only* thing left on the published artifact.

None of this is done for verification's sake alone; each item is a real defect.

## What changed

### Debug output goes to the n8n logger

Debug Mode printed JSON lines to **stdout**. Two problems: the host's log got them with no execution context attached, and n8n Cloud does not allow a community node to write to the console at all.

A small sink is now built once per execution from `this.logger`, and entries route by level — errors as errors, warnings as warnings, everything else as debug. Turning Debug Mode on and off behaves exactly as before.

Two deliberate exceptions, both preserved:

- **Three diagnostics were intentionally *not* gated by Debug Mode** — a primary news search failing before a fallback, and either fallback failing after it. The comment in the code says why: the cause must stay visible when the fallback succeeds and no error item reaches the workflow. They are still always-on, now as logger warnings.
- **The console calls in `fallbackSearch` and `directSearch` were deleted, not rerouted.** Each duplicated a message the function already returns in its result object or carries on the error it throws. Nothing is lost.

### Cloud-restricted primitives

- `setTimeout` → `sleep` from `n8n-workflow` (two sites). Behaviour unchanged.
- `inputs`/`outputs` → `NodeConnectionTypes.Main` instead of the `'main'` literal.

This last one put our own lint config and n8n's scanner in direct conflict — `n8n-nodes-base/node-class-description-inputs-wrong-regular-node` demands the literal, `@n8n/community-nodes/node-connection-type-literal` demands the enum. n8n's own scanner config resolves it by turning the former off, so `eslint.config.js` now matches it, with a comment saying so.

### package.json

- Added `peerDependencies: { "n8n-workflow": "*" }` — what the rules require and what verified nodes ship.
- Removed `resolutions` — a **yarn**-only field. npm never applied it: the lockfile records no `overrides` key and resolves `@n8n/client-oauth2`'s axios to 1.15.0 on its own. Dead boilerplate.

## Two rules left failing on purpose

**`node-param-default-missing` (15).** The rule does not recognise a non-literal default. `eslint.config.js` already carried that finding; I confirmed it with a probe package — a parameter with `default: 10` passes, an identical one with `default: CONSTS.MAX` is reported as missing. Its autofix then inserts a **duplicate** `default` key above the real one. Complying would mean inlining the `DEFAULT_PARAMETERS` constants into the description, creating a second source of truth for values the execute path reads from the same object.

**`node-param-collection-type-unsorted-items` (3).** Alphabetising would break the deliberate grouping recorded next to it in `eslint.config.js` (page-content options kept together).

**`require-node-api-error` (15)** is genuinely worth doing and is **not** in this PR. It needs an `INode` threaded into `directWebSearch` / `directImageSearch` / `paginateWithVqd` so they can construct `NodeApiError`, which touches **66 test call sites** and the node's error layer. That deserves its own change and its own review.

## Verification

- `npm test` — **466 tests / 20 suites pass**
- `npm run lint` — exit 0
- `npm run build` — exit 0, icon copied
- `npm run check-package` — 28 files, 270 kB, gate clean
- Lockfile still reports `32.14.0` in both `.version` and `.packages[""].version`, so the release workflow's check still passes

One note on method: the scanner CLI cannot finish on Windows — after the provenance check passes it hands `tar` a mangled temp path and aborts. The provenance leg is the CLI's own result; the two lint legs were run through the scanner's exported `analyzePackage()` with its own config and its own file patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
