### PR TITLE
chore: release 32.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [32.15.0] - 2026-09-12
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,80 @@
+# v32.15.0 — Errors that say what happened
+
+**Release Date:** 2026-09-12
+
+No new options, and nothing about searching changes. This release is about what
+the node tells you when something goes wrong, and where it says it.
+
+---
+
+## A failed search now carries the status code
+
+When DuckDuckGo turned a request away, the node caught the failure and threw a
+plain error carrying one sentence. The status code and the response body were
+discarded on that line, before anything could show them. A rate-limited run told
+you **"Too many requests"** and gave you nothing to check it against — no 429, no
+body, nothing to tell it apart from a different failure with a similar message.
+
+Those failures are now `NodeApiError`, the class n8n renders with the HTTP detail
+attached. The wording you already know is unchanged; the status code and the
+response now travel with it.
+
+| What happened | Before | Now |
+|---|---|---|
+| DuckDuckGo answered 429 / 5xx / 403 | message only | message **+ status code + response** |
+| Timeout, unknown host, refused connection | message only | message only |
+
+The second row is deliberate. A request that never got an answer has no HTTP
+context to keep — and routing it through `NodeApiError` anyway would have
+replaced the node's own wording with n8n's generic text for those codes, turning
+*"Web search request timed out. Please try again."* into *"The connection was
+aborted, perhaps the server is offline"*. Those failures use
+`NodeOperationError`, which leaves the message alone.
+
+Four places still re-throw the original error untouched, and that is the right
+answer in each: two carry a message whose guidance is the whole point of it — a
+parser failure, or a bot-challenge explanation — and two are the image-search
+retry, which reads the original error's status to decide whether to fetch a
+fresh token.
+
+## Debug Mode writes to the n8n log, not the server console
+
+Debug Mode used to print JSON lines to standard output. They landed in the
+host's log with no execution attached, so finding the ones belonging to a
+particular run meant guessing from timestamps. They now go through n8n's own
+logger — errors as errors, warnings as warnings, the rest as debug — so they
+arrive with the context n8n already tracks. Turning Debug Mode on and off
+behaves exactly as before.
+
+Three diagnostics were deliberately **not** gated by Debug Mode: a news search
+failing before the fallback runs, and either fallback failing after it. They stay
+always-on, because when the fallback then succeeds no error reaches the workflow
+at all and the log is the only place the cause appears.
+
+## Under the hood
+
+`setTimeout` is replaced by n8n's `sleep` helper, `inputs`/`outputs` use
+`NodeConnectionTypes.Main`, `package.json` declares
+`peerDependencies: { "n8n-workflow": "*" }`, and a `resolutions` field that never
+did anything — it is a yarn field, and this project builds with npm — is gone.
+Behaviour is unchanged by all four.
+
+Together with the logging change, these take the violations that
+`@n8n/scan-community-package` reports against the published package from **57 to
+10**. Every one of the ten that remain is a runtime dependency, which is a
+separate and much larger piece of work.
+
+## Maintenance
+
+CI steps have timeouts, which they did not before. The release archive is
+checked against what npm actually publishes, on every push and again inside the
+release itself — a tag can be pushed before CI finishes, and an npm version
+cannot be taken back. Dev dependencies updated.
+
+476 tests across 22 suites.
+
+---
+
 # v32.14.0 — Ranking rules
 
 **Release Date:** 2026-09-09

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.14.0",
+  "version": "32.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-duckduckgo-search",
-      "version": "32.14.0",
+      "version": "32.15.0",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-duckduckgo-search",
-  "version": "32.14.0",
+  "version": "32.15.0",
   "description": "AI Agent-ready n8n community node for DuckDuckGo search. Search the web, images, news, and videos with no API key required and no outbound telemetry. Optionally fetch and extract the main text of result pages or any URL, and get DuckDuckGo Instant Answers. Provides robust error handling, fallback result paths for news and video, and clean output for downstream AI Agent use.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Version bump and notes for **32.15.0**. npm is still on 32.14.0 and `main` is four PRs ahead of it.

## What is in the release

Nothing about searching changes. This one is about what the node says when something goes wrong, and where it says it.

| PR | user-visible? |
|---|---|
| #63 — search failures carry the status code | **yes** |
| #62 — debug output goes to the n8n logger | **yes** |
| #60 — CI timeouts, package-contents gate, run summary | no |
| #53 — dev-dependency bumps | no |

Minor rather than patch: both #62 and #63 change observable behaviour — where debug output lands, and the class and detail of a thrown error — without breaking anything.

## Checks run here

- `npm test` — **476 tests / 22 suites pass**
- `npm run lint` — exit 0
- `npm run check-package` — 28 files, 271 kB, gate clean, and it reports `32.15.0`
- `package-lock.json` carries `32.15.0` in **both** `.version` and `.packages[""].version`, which the release workflow checks and refuses to publish without
- The release workflow's own body extractor was run against the new `RELEASE_NOTES.md` locally: **75 lines, opening on `# v32.15.0 — Errors that say what happened`** and ending on the last line of that section. A missing or mismatched section fails the release, so this is worth knowing before the tag rather than after.

## After merging

```bash
git tag -a v32.15.0 -m "Release v32.15.0 - errors that say what happened"
git push origin v32.15.0
```

The tag push publishes to npm with provenance and creates the GitHub release. Nothing else to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
